### PR TITLE
Overhaul commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,17 +96,56 @@ target_include_directories(${CMAKE_PROJECT_NAME}
 target_include_directories(${CMAKE_PROJECT_NAME} SYSTEM
     PRIVATE ${CMAKE_SOURCE_DIR}/vendor)
 
-target_link_libraries(
+# black magic to link libraries as if they were system libraries
+function(target_link_libraries_system target)
+    set(options PRIVATE PUBLIC INTERFACE)
+    cmake_parse_arguments(TLLS "${options}" "" "" ${ARGN})
+
+    foreach(op ${options})
+        if(TLLS_${op})
+            set(scope ${op})
+        endif()
+    endforeach(op)
+
+    set(libs ${TLLS_UNPARSED_ARGUMENTS})
+
+    foreach(lib ${libs})
+        get_target_property(lib_include_dirs ${lib} INTERFACE_INCLUDE_DIRECTORIES)
+
+        if(lib_include_dirs)
+            if(scope)
+                target_include_directories(${target} SYSTEM ${scope} ${lib_include_dirs})
+            else()
+                target_include_directories(${target} SYSTEM PRIVATE ${lib_include_dirs})
+            endif()
+        else()
+            message("Warning: ${lib} doesn't set INTERFACE_INCLUDE_DIRECTORIES. No include_directories set.")
+        endif()
+
+        if(scope)
+            target_link_libraries(${target} ${scope} ${lib})
+        else()
+            target_link_libraries(${target} ${lib})
+        endif()
+    endforeach()
+endfunction(target_link_libraries_system)
+
+target_link_libraries_system(
     ${CMAKE_PROJECT_NAME}
+    PRIVATE
     xtl
     xtensor
     xtensor-blas
-    lapack
-    OpenMP::OpenMP_CXX
     libfort::fort
     fmt::fmt
     spdlog::spdlog
     Microsoft.GSL::GSL
+)
+target_link_libraries(
+    ${CMAKE_PROJECT_NAME}
+    PRIVATE
+    lapack
+    OpenMP::OpenMP_CXX
     ${BLAS_LIBRARIES}
     ${LAPACK_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ target_compile_definitions(spdlog PUBLIC SPDLOG_SHORT_LEVEL_NAMES={\"[trace]\ \ 
 target_link_libraries(spdlog PUBLIC fmt::fmt)
 
 target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE QSYN_VERSION="${CMAKE_PROJECT_VERSION}")
-
+target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall -Werror)
 target_include_directories(${CMAKE_PROJECT_NAME}
     PRIVATE ${CMAKE_SOURCE_DIR}/src)
 

--- a/src/argparse/arg_parser.hpp
+++ b/src/argparse/arg_parser.hpp
@@ -133,11 +133,9 @@ public:
     [[nodiscard]] MutuallyExclusiveGroup add_mutually_exclusive_group();
     [[nodiscard]] SubParsers add_subparsers();
 
-    bool parse_args(std::string const& line);
     bool parse_args(std::vector<std::string> const& tokens);
     bool parse_args(TokensView);
 
-    std::pair<bool, std::vector<Token>> parse_known_args(std::string const& line);
     std::pair<bool, std::vector<Token>> parse_known_args(std::vector<std::string> const& tokens);
     std::pair<bool, std::vector<Token>> parse_known_args(TokensView);
 
@@ -200,7 +198,6 @@ private:
 
     // parse subroutine
     std::string _get_activated_subparser_name() const { return _pimpl->activated_subparser.value_or(""); }
-    bool _tokenize(std::string const& line);
     bool _parse_options(TokensView tokens);
     bool _parse_positional_arguments(TokensView tokens, std::vector<Token>& unrecognized);
     void _fill_unparsed_args_with_defaults();

--- a/src/argparse/arg_parser_print.cpp
+++ b/src/argparse/arg_parser_print.cpp
@@ -149,17 +149,20 @@ std::string wrap_text(std::string const& str, size_t max_help_width) {
     if (!dvlab::utils::is_terminal()) return str;
 
     std::vector<std::string> lines = dvlab::str::split(str, "\n");
-    for (auto&& [i, line] : tl::views::enumerate(lines)) {
-        if (line.size() < max_help_width) continue;
 
-        size_t const pos = line.find_last_of(' ', max_help_width);
+    // NOTE - the following code modifies the vector while iterating over it.
+    //        don't use range-based for loop here.
+    for (size_t i = 0; i < lines.size(); ++i) {
+        if (lines[i].size() < max_help_width) continue;
+
+        size_t const pos = lines[i].find_last_of(' ', max_help_width);
 
         if (pos == std::string::npos) {
-            lines.insert(dvlab::iterator::next(std::begin(lines), i + 1), line.substr(max_help_width));
-            line = line.substr(0, max_help_width);
+            lines.insert(dvlab::iterator::next(std::begin(lines), i + 1), lines[i].substr(max_help_width));
+            lines[i] = lines[i].substr(0, max_help_width);
         } else {
-            lines.insert(dvlab::iterator::next(std::begin(lines), i + 1), line.substr(pos + 1));
-            line = line.substr(0, pos);
+            lines.insert(dvlab::iterator::next(std::begin(lines), i + 1), lines[i].substr(pos + 1));
+            lines[i] = lines[i].substr(0, pos);
         }
     }
 

--- a/src/argparse/arg_type.cpp
+++ b/src/argparse/arg_type.cpp
@@ -26,7 +26,7 @@ ArgType<std::string>::ConstraintType choices_allow_prefix(std::vector<std::strin
     dvlab::utils::Trie trie{std::begin(choices), std::end(choices)};
 
     return [choices, trie](std::string const& val) -> bool {
-        auto is_exact_match_to_choice = [&val, &trie](std::string const& choice) -> bool {
+        auto is_exact_match_to_choice = [&val](std::string const& choice) -> bool {
             return dvlab::str::tolower_string(val) == choice;
         };
         auto freq = trie.frequency(dvlab::str::tolower_string(val));
@@ -127,7 +127,7 @@ ActionCallbackType store_false(ArgType<bool>& arg) {
 ActionCallbackType help(ArgType<bool>& arg) {
     arg.mark_as_help_action();
     arg.nargs(0ul);
-    return [&arg](TokensView) -> bool {
+    return [](TokensView) -> bool {
         return true;
     };
 }
@@ -135,7 +135,7 @@ ActionCallbackType help(ArgType<bool>& arg) {
 ActionCallbackType version(ArgType<bool>& arg) {
     arg.mark_as_version_action();
     arg.nargs(0ul);
-    return [&arg](TokensView) -> bool {
+    return [](TokensView) -> bool {
         return true;
     };
 }

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1,0 +1,309 @@
+/****************************************************************************
+  PackageName  [ cli ]
+  Synopsis     [ Define basic functionalities and helpers for CLI ]
+  Author       [ Design Verification Lab, Chia-Hsu Chuang ]
+  Copyright    [ Copyright(c) 2023 DVLab, GIEE, NTU, Taiwan ]
+****************************************************************************/
+
+#include "./cli.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <regex>
+#include <tl/enumerate.hpp>
+
+namespace dvlab {
+/**
+ * @brief open a dofile and push it to the dofile stack.
+ *
+ * @param filepath the file to be opened
+ * @return true
+ * @return false
+ */
+bool dvlab::CommandLineInterface::open_dofile(std::string const& filepath) {
+    constexpr size_t dofile_stack_limit = 256;
+    if (this->stop_requested()) {
+        return false;
+    }
+    if (_dofile_stack.size() >= dofile_stack_limit) {
+        spdlog::error("dofile stack overflow ({})!!", dofile_stack_limit);
+        return false;
+    }
+
+    _dofile_stack.push(std::ifstream(filepath));
+
+    if (!_dofile_stack.top().is_open()) {
+        close_dofile();
+        return false;
+    }
+    return true;
+}
+
+/**
+ * @brief close the top dofile in the dofile stack.
+ *
+ */
+void dvlab::CommandLineInterface::close_dofile() {
+    assert(_dofile_stack.size());
+    _dofile_stack.pop();
+}
+
+/**
+ * @brief register a command to the CLI.
+ *
+ * @param name the command name
+ * @param nMandChars the number of characters to be matched.
+ * @param cmd the command to be registered
+ * @return true
+ * @return false
+ */
+bool dvlab::CommandLineInterface::add_command(dvlab::Command cmd) {
+    // Make sure cmd hasn't been registered and won't cause ambiguity
+    auto name        = cmd.get_name();
+    auto n_req_chars = _identifiers.shortest_unique_prefix(cmd.get_name()).size();
+    if (!cmd.initialize(n_req_chars)) {
+        spdlog::error("Failed to initialize command `{}`!!", name);
+        return false;
+    }
+
+    if (_commands.contains(name)) {
+        spdlog::error("Command name `{}` conflicts with existing commands or aliases!!", name);
+        return false;
+    }
+
+    if (_aliases.contains(name)) {
+        spdlog::warn("Command name `{}` is shadowed by an alias with the same name...", name);
+    }
+
+    _identifiers.insert(name);
+    _commands.emplace(name, std::make_unique<dvlab::Command>(std::move(cmd)));
+
+    for (auto& [name, c] : _commands) {
+        if (auto n_req = _identifiers.shortest_unique_prefix(name).size(); n_req != c->get_num_required_chars()) {
+            c->set_num_required_chars(n_req);
+        }
+    }
+    return true;
+}
+
+bool dvlab::CommandLineInterface::add_alias(std::string const& alias, std::string const& replace_str) {
+    if (_aliases.contains(alias)) {
+        spdlog::warn("Overwriting the definition of alias `{}`...", alias);
+    }
+    if (_commands.contains(alias)) {
+        spdlog::warn("Alias `{}` will shadow a command with the same name...", alias);
+    }
+
+    if (!_aliases.contains(alias)) {
+        _identifiers.insert(alias);
+    }
+    _aliases.insert_or_assign(alias, replace_str);
+
+    for (auto& [name, c] : _commands) {
+        if (auto n_req = _identifiers.shortest_unique_prefix(name).size(); n_req != c->get_num_required_chars()) {
+            c->set_num_required_chars(n_req);
+        }
+    }
+
+    return true;
+}
+
+bool dvlab::CommandLineInterface::remove_alias(std::string const& alias) {
+    if (!_identifiers.erase(alias)) {
+        return false;
+    }
+    _aliases.erase(alias);
+
+    for (auto& [name, c] : _commands) {
+        if (auto n_req = _identifiers.shortest_unique_prefix(name).size(); n_req != c->get_num_required_chars()) {
+            c->set_num_required_chars(n_req);
+        }
+    }
+
+    return true;
+}
+
+bool dvlab::CommandLineInterface::add_variable(std::string const& key, std::string const& value) {
+    if (_variables.contains(key)) {
+        spdlog::error("Variable `{}` is already defined!!", key);
+        return false;
+    }
+    _variables.insert_or_assign(key, value);
+    return true;
+}
+
+bool dvlab::CommandLineInterface::remove_variable(std::string const& key) {
+    if (!_variables.erase(key)) {
+        spdlog::error("Variable `{}` is not defined!!", key);
+        return false;
+    }
+    return true;
+}
+
+bool dvlab::CommandLineInterface::add_variables_from_dofiles(std::string const& filepath, std::span<std::string> arguments) {
+    // parse the string
+    // "//!ARGS <ARG1> <ARG2> ... <ARGn>"
+    // and check if for all k = 1 to n,
+    // _variables[to_string(k)] is mapped to a valid value
+
+    // To enable keyword arguments, also map the names <ARGk>
+    // to _variables[to_string(k)]
+
+    std::ifstream dofile(filepath);
+
+    if (!dofile.is_open()) {
+        spdlog::error("cannot open file \"{}\"!!", filepath);
+        return false;
+    }
+
+    if (dofile.peek() == std::ifstream::traits_type::eof()) {
+        spdlog::error("file \"{}\" is empty!!", filepath);
+        return false;
+    }
+    std::string line{""};
+    while (line == "") {  // skip empty lines
+        std::getline(dofile, line);
+    };
+
+    dofile.close();
+
+    std::vector<std::string> tokens = dvlab::str::split(line, " ");
+
+    std::erase_if(tokens, [](std::string const& token) { return token == ""; });
+
+    if (tokens.empty()) return true;
+
+    if (tokens[0] == "//!ARGS") {
+        tokens.erase(std::begin(tokens));
+        static std::regex const valid_variable_name(R"([a-zA-Z_][\w]*)");
+
+        std::vector<std::string> keys;
+        for (auto const& token : tokens) {
+            if (!regex_match(token, valid_variable_name)) {
+                spdlog::error("invalid argument name \"{}\" in \"//!ARGS\" directive", token);
+                return false;
+            }
+            keys.emplace_back(token);
+        }
+
+        if (arguments.size() != keys.size()) {
+            spdlog::error("wrong number of arguments provided, expected {} but got {}!!", keys.size(), arguments.size());
+            spdlog::error("Usage: ... {} <{}>", filepath, fmt::join(keys, "> <"));
+            return false;
+        }
+
+        for (size_t i = 0; i < keys.size(); ++i) {
+            _variables.insert_or_assign(keys[i], arguments[i]);
+        }
+    }
+
+    for (size_t i = 0; i < arguments.size(); ++i) {
+        _variables.insert_or_assign(std::to_string(i + 1), arguments[i]);
+    }
+
+    return true;
+}
+
+/**
+ * @brief handle the SIGINT signal. Wrap the handler in a static function so that it can be passed to the signal function.
+ *
+ * @param signum
+ */
+void dvlab::CommandLineInterface::sigint_handler(int signum) {
+    if (_listening_for_inputs) {
+        _reset_read_buffer();
+        fmt::println("");
+        _print_prompt();
+    } else if (_command_thread.has_value()) {
+        // there is an executing command
+        _command_thread->request_stop();
+    } else {
+        spdlog::critical("Failed to handle the SIGINT signal. Exiting...");
+        exit(signum);
+    }
+}
+
+std::optional<std::string> CommandLineInterface::_dequote(std::string_view str) const {
+    std::string result;
+    using parse_state = CommandLineInterface::parse_state;
+    parse_state state = parse_state::normal;
+    for (auto&& [i, ch] : str | tl::views::enumerate) {
+        switch (state) {
+            case parse_state::normal: {
+                if (ch == '\'' && !_is_escaped(str, i)) {
+                    state = parse_state::single_quote;
+                    continue;
+                } else if (ch == '\"' && !_is_escaped(str, i)) {
+                    state = parse_state::double_quote;
+                    continue;
+                }
+                break;
+            }
+            case parse_state::single_quote: {
+                if (ch == '\'') {
+                    state = parse_state::normal;
+                    continue;
+                }
+                break;
+            }
+            case parse_state::double_quote: {
+                if (ch == '\"' && !_is_escaped(str, i)) {
+                    state = parse_state::normal;
+                    continue;
+                }
+                break;
+            }
+        }
+
+        if (_should_be_escaped(ch, state)) result += '\\';
+        result += ch;
+    }
+
+    return state == parse_state::normal ? std::make_optional(result) : std::nullopt;
+}
+
+/**
+ * @brief check if the character `ch` should be escaped in the given state.
+ *
+ * @param ch
+ * @param state
+ * @return true
+ * @return false
+ */
+bool CommandLineInterface::_should_be_escaped(char ch, dvlab::CommandLineInterface::parse_state state) const {
+    using parse_state = dvlab::CommandLineInterface::parse_state;
+    switch (state) {
+        case parse_state::normal:
+            return false;
+        case parse_state::single_quote:
+            return dvlab::CommandLineInterface::special_chars.find(ch) != std::string::npos;
+        case parse_state::double_quote:
+            return dvlab::CommandLineInterface::special_chars.find(ch) != std::string::npos && dvlab::CommandLineInterface::double_quote_special_chars.find(ch) == std::string::npos;
+    }
+    return false;
+}
+/**
+ * @brief check if the character at `str`[`pos`] is escaped.
+ *
+ * @param str
+ * @param pos
+ * @return true
+ * @return false
+ */
+bool CommandLineInterface::_is_escaped(std::string_view str, size_t pos) const {
+    // the first character cannot be escaped
+    if (pos == 0) return false;
+    // checks how many `\\` precedes the character at `pos`
+    auto n = str.find_last_not_of('\\', pos - 1);
+
+    // if all the characters preceding `str`[`pos`] are `\\`
+    if (n == std::string::npos) n = 0;
+
+    // if the number of `\\` preceding the character at `pos` is odd, it is escaped
+    // e.g., the `'` in `\'` is escaped,
+    //                  `\\'` is not escaped,
+    //                  `\\\'` is escaped, etc.
+    return (pos - n) % 2 == 0;
+}
+
+}  // namespace dvlab

--- a/src/cli/cli_cmd.cpp
+++ b/src/cli/cli_cmd.cpp
@@ -6,10 +6,6 @@
 ****************************************************************************/
 #include <spdlog/spdlog.h>
 
-#include <cstddef>
-#include <cstdlib>
-#include <string>
-
 #include "cli/cli.hpp"
 #include "fmt/color.h"
 #include "spdlog/common.h"
@@ -42,7 +38,7 @@ Command alias_cmd(CommandLineInterface& cli) {
         [&cli](ArgumentParser const& parser) {
             if (parser.parsed("-d")) {
                 if (parser.parsed("alias") || parser.parsed("replace-str")) {
-                    fmt::println(stderr, "Error: cannot specify alias and replace-str when deleting alias!!");
+                    fmt::println(stderr, "Error: cannot specify replacement string when deleting alias!!");
                     return CmdExecResult::error;
                 }
                 if (!cli.remove_alias(parser.get<std::string>("-d"))) {
@@ -51,14 +47,67 @@ Command alias_cmd(CommandLineInterface& cli) {
                 return CmdExecResult::done;
             }
 
+            if (!(parser.parsed("alias") && parser.parsed("replace-str"))) {
+                fmt::println(stderr, "Error: alias and replacement string must be specified!!");
+                return CmdExecResult::error;
+            }
+
             auto alias       = parser.get<std::string>("alias");
             auto replace_str = parser.get<std::string>("replace-str");
 
-            if (std::ranges::any_of(alias, [](char ch) { return isspace(ch); })) {
-                fmt::println(stderr, "Error: alias cannot contain whitespaces!!");
+            if (cli.add_alias(alias, replace_str)) {
                 return CmdExecResult::error;
             }
-            if (cli.add_alias(alias, replace_str)) {
+
+            return CmdExecResult::done;
+        }};
+}
+
+Command set_variable_cmd(CommandLineInterface& cli) {
+    return {
+        "set",
+        [](ArgumentParser& parser) {
+            parser.description("set a variable");
+
+            parser.add_argument<std::string>("variable")
+                .required(false)
+                .help("the variable to set");
+
+            parser.add_argument<std::string>("value")
+                .required(false)
+                .help("the value to set");
+
+            parser.add_argument<std::string>("-d", "--delete")
+                .metavar("variable")
+                .help("delete the variable");
+        },
+
+        [&cli](ArgumentParser const& parser) {
+            if (parser.parsed("-d")) {
+                if (parser.parsed("variable") || parser.parsed("value")) {
+                    fmt::println(stderr, "Error: cannot specify values when deleting variable!!");
+                    return CmdExecResult::error;
+                }
+                if (!cli.remove_variable(parser.get<std::string>("-d"))) {
+                    return CmdExecResult::error;
+                }
+                return CmdExecResult::done;
+            }
+
+            if (!(parser.parsed("variable") && parser.parsed("value"))) {
+                fmt::println(stderr, "Error: variable and value must be specified!!");
+                return CmdExecResult::error;
+            }
+
+            auto variable = parser.get<std::string>("variable");
+            auto value    = parser.get<std::string>("value");
+
+            if (std::ranges::any_of(variable, [](char ch) { return isspace(ch); })) {
+                fmt::println(stderr, "Error: variable cannot contain whitespaces!!");
+                return CmdExecResult::error;
+            }
+
+            if (!cli.add_variable(variable, value)) {
                 return CmdExecResult::error;
             }
 
@@ -94,8 +143,8 @@ Command help_cmd(CommandLineInterface& cli) {
         }};
 }
 
-Command quit_cmd(CommandLineInterface& cli) {
-    return {"qquit",
+Command exit_cmd(CommandLineInterface& cli) {
+    return {"exit",
             [](ArgumentParser& parser) {
                 parser.description("quit Qsyn");
 
@@ -107,14 +156,13 @@ Command quit_cmd(CommandLineInterface& cli) {
                 using namespace std::string_literals;
                 if (parser.get<bool>("-force")) return CmdExecResult::quit;
 
-                std::string const prompt = "Are you sure to quit (Yes/[No])? ";
+                std::string const prompt = "Are you sure you want to exit (Yes/[No])? ";
 
-                if (cli.listen_to_input(std::cin, prompt, {.allow_browse_history = false, .allow_tab_completion = false}) == CmdExecResult::quit) {
+                auto [exec_result, input] = cli.listen_to_input(std::cin, prompt, {.allow_browse_history = false, .allow_tab_completion = false});
+                if (exec_result == CmdExecResult::quit) {
                     fmt::print("EOF [assumed Yes]");
                     return CmdExecResult::quit;
                 }
-
-                auto input = dvlab::str::tolower_string(dvlab::str::strip_leading_spaces(cli.get_read_buffer()));
 
                 if (input.empty()) return CmdExecResult::done;
 
@@ -202,33 +250,11 @@ Command usage_cmd() {
             }};
 }
 
-// Command verbose_cmd() {
-//     return {"verbose",
-//             [](ArgumentParser& parser) {
-//                 parser.description("set verbose level to 0-9 (default: 3)");
-
-//                 parser.add_argument<size_t>("level")
-//                     .constraint([](size_t const& val) {
-//                         if (val == 353 || (0 <= val && val <= 9)) return true;  // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-//                         fmt::println(stderr, "Error: verbose level should be 0-9!!");
-//                         return false;
-//                     })
-//                     .help("0: silent, 1-3: normal usage, 4-6: detailed info, 7-9: prolix debug info");
-//             },
-
-//             [](ArgumentParser const& parser) {
-//                 VERBOSE = parser.get<size_t>("level");
-//                 fmt::println("Note: verbose level is set to {}", VERBOSE);
-
-//                 return CmdExecResult::done;
-//             }};
-// }
-
 Command logger_cmd() {
     Command cmd{
         "logger",
         [](ArgumentParser& parser) {
-            std::vector<std::string> log_levels = {"off", "critical", "error", "warn", "info", "debug", "trace"};
+            std::vector<std::string> log_levels = {"off", "critical", "error", "warning", "info", "debug", "trace"};
             parser.description("display and set the logger's status");
 
             auto parsers = parser.add_subparsers()
@@ -237,16 +263,7 @@ Command logger_cmd() {
         [](ArgumentParser const& /*parser*/) {
             fmt::println("Logger Level: {}", spdlog::level::to_string_view(spdlog::get_level()));
             std::vector<std::string> masked;
-            std::vector<std::string> log_levels = {"critical", "error", "warn", "info", "debug", "trace"};
-            // for (auto& level : log_levels) {
-            //     if (LOGGER.is_masked(*Logger::str_to_log_level(level))) {
-            //         masked.push_back(level);
-            //     }
-            // }
-
-            // if (masked.size()) {
-            //     fmt::println("Masked logging levels: {}", fmt::join(masked, ", "));
-            // }
+            std::vector<std::string> log_levels = {"critical", "error", "warning", "info", "debug", "trace"};
 
             return CmdExecResult::done;
         }};
@@ -260,7 +277,7 @@ Command logger_cmd() {
              spdlog::log(spdlog::level::level_enum::off, "Regular printing (level `off`)");
              spdlog::critical("A log message with level `critical`");
              spdlog::error("A log message with level `error`");
-             spdlog::warn("A log message with level `warn`");
+             spdlog::warn("A log message with level `warning`");
              spdlog::info("A log message with level `info`");
              spdlog::debug("A log message with level `debug`");
              spdlog::trace("A log message with level `trace`");
@@ -272,8 +289,8 @@ Command logger_cmd() {
          [](ArgumentParser& parser) {
              parser.description("set logger level");
              parser.add_argument<std::string>("level")
-                 .constraint(choices_allow_prefix(std::vector<std::string>{"off", "critical", "error", "warn", "info", "debug", "trace"}))
-                 .help("set log levels. Levels (ascending): off, critical, error, warn, info, debug, trace");
+                 .constraint(choices_allow_prefix(std::vector<std::string>{"off", "critical", "error", "warning", "info", "debug", "trace"}))
+                 .help("set log levels. Levels (ascending): off, critical, error, warning, info, debug, trace");
          },
          [](ArgumentParser const& parser) {
              auto level = spdlog::level::from_str(parser.get<std::string>("level"));
@@ -281,65 +298,6 @@ Command logger_cmd() {
              spdlog::info("Setting logger level to \"{}\"", spdlog::level::to_string_view(level));
              return CmdExecResult::done;
          }});
-
-    // cmd.add_subcommand(
-    //     {"history",
-    //      [](ArgumentParser& parser) {
-    //          parser.description("print logger history");
-    //          parser.add_argument<size_t>("num_history")
-    //              .nargs(NArgsOption::optional)
-    //              .metavar("N")
-    //              .help("print log history. If specified, print the lastest N logs");
-    //      },
-    //      [](ArgumentParser const& parser) {
-    //          if (parser.parsed("num_history")) {
-    //              LOGGER.print_logs(parser.get<size_t>("num_history"));
-    //          } else {
-    //              LOGGER.print_logs();
-    //          }
-    //          return CmdExecResult::done;
-    //      }});
-
-    // cmd.add_subcommand(
-    //     {"mask",
-    //      [](ArgumentParser& parser) {
-    //          parser.description("set logger mask")
-    //              .option_prefix("+-");
-    //          auto add_filter_group = [&parser](std::string const& group_name) {
-    //              auto group = parser.add_mutually_exclusive_group();
-    //              group.add_argument<bool>("+" + group_name)
-    //                  .action(store_true)
-    //                  .help("unmask " + group_name + " logs");
-    //              group.add_argument<bool>("-" + group_name)
-    //                  .action(store_true)
-    //                  .help("mask " + group_name + " logs");
-    //          };
-
-    //          std::vector<std::string> log_levels = {"fatal", "error", "warn", "info", "debug", "trace"};
-
-    //          for (auto& group : log_levels) {
-    //              if (group == "none") continue;
-    //              add_filter_group(group);
-    //          }
-    //      },
-    //      [](ArgumentParser const& parser) {
-    //          using dvlab::Logger;
-
-    //          std::vector<std::string> log_levels = {"fatal", "error", "warn", "info", "debug", "trace"};
-
-    //          for (auto& group : log_levels) {
-    //              auto level = Logger::str_to_log_level(group);
-    //              assert(level.has_value());
-    //              if (parser.parsed("+" + group)) {
-    //                  LOGGER.unmask(*level);
-    //                  LOGGER.debug("Unmasked logger level: {}", Logger::log_level_to_str(*level));
-    //              } else if (parser.parsed("-" + group)) {
-    //                  LOGGER.mask(*level);
-    //                  LOGGER.debug("Masked logger level: {}", Logger::log_level_to_str(*level));
-    //              }
-    //          }
-    //          return CmdExecResult::done;
-    //      }});
 
     return cmd;
 }
@@ -377,12 +335,14 @@ Command clear_cmd() {
 
 bool add_cli_common_cmds(dvlab::CommandLineInterface& cli) {
     if (!(cli.add_command(alias_cmd(cli)) &&
-          cli.add_command(quit_cmd(cli)) &&
+          cli.add_command(set_variable_cmd(cli)) &&
+          cli.add_command(exit_cmd(cli)) &&
+          cli.add_alias("qquit", "exit") &&
+          cli.add_alias("q", "exit") &&
           cli.add_command(history_cmd(cli)) &&
           cli.add_command(help_cmd(cli)) &&
           cli.add_command(dofile_cmd(cli)) &&
           cli.add_command(usage_cmd()) &&
-          //   cli.add_command(verbose_cmd()) &&
           cli.add_command(seed_cmd()) &&
           cli.add_command(clear_cmd()) &&
           cli.add_command(logger_cmd()))) {

--- a/src/cli/cli_command_type.cpp
+++ b/src/cli/cli_command_type.cpp
@@ -61,8 +61,8 @@ bool dvlab::Command::initialize(size_t n_req_chars) {
  * @return true if succeeded
  * @return false if failed
  */
-CmdExecResult dvlab::Command::execute(std::string const& option) {
-    if (!_parser.parse_args(option)) {
+CmdExecResult dvlab::Command::execute(std::vector<argparse::Token> options) {
+    if (!_parser.parse_args(options)) {
         return CmdExecResult::error;
     }
 

--- a/src/cli/cli_listen.cpp
+++ b/src/cli/cli_listen.cpp
@@ -149,8 +149,6 @@ std::pair<CmdExecResult, std::string> dvlab::CommandLineInterface::listen_to_inp
 
     settings_restorer restorer{this, prompt};
 
-    parse_state state = parse_state::normal;
-
     _reset_read_buffer();
     _print_prompt();
 

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -16,12 +16,15 @@
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
+#include <gsl/narrow>
 #include <limits>
 #include <ranges>
 #include <string>
+#include <utility>
 
 #include "qcir/gate_type.hpp"
 #include "qcir/qcir_gate.hpp"
+#include "qsyn/qsyn_type.hpp"
 #include "util/util.hpp"
 
 using namespace qsyn::qcir;
@@ -131,7 +134,7 @@ std::ostream& operator<<(std::ostream& os, PhysicalQubit const& q) {
  * @param source false: from 0, true: from 1
  * @param pred predecessor
  */
-void PhysicalQubit::mark(bool source, size_t pred) {
+void PhysicalQubit::mark(bool source, QubitIdType pred) {
     _marked = true;
     _source = source;
     _pred   = pred;
@@ -168,8 +171,8 @@ void PhysicalQubit::reset() {
  * @param target
  * @return tuple<size_t, size_t> (index of next qubit, cost)
  */
-std::tuple<size_t, size_t> Device::get_next_swap_cost(size_t source, size_t target) {
-    size_t next_idx         = _predecessor[source][target];
+std::tuple<QubitIdType, QubitIdType> Device::get_next_swap_cost(QubitIdType source, QubitIdType target) {
+    auto next_idx           = _predecessor[source][target];
     PhysicalQubit& q_source = get_physical_qubit(source);
     PhysicalQubit& q_next   = get_physical_qubit(next_idx);
     size_t cost             = std::max(q_source.get_occupied_time(), q_next.get_occupied_time());
@@ -184,13 +187,13 @@ std::tuple<size_t, size_t> Device::get_next_swap_cost(size_t source, size_t targ
  * @param id logical
  * @return size_t
  */
-size_t Device::get_physical_by_logical(size_t id) {
+QubitIdType Device::get_physical_by_logical(QubitIdType id) {
     for (auto& [_, phy] : _qubit_list) {
         if (phy.get_logical_qubit() == id) {
             return phy.get_id();
         }
     }
-    return SIZE_MAX;
+    return max_qubit_id;
 }
 
 /**
@@ -199,7 +202,7 @@ size_t Device::get_physical_by_logical(size_t id) {
  * @param a Id of first qubit
  * @param b Id of second qubit
  */
-void Device::add_adjacency(size_t a, size_t b) {
+void Device::add_adjacency(QubitIdType a, QubitIdType b) {
     if (a > b) std::swap(a, b);
     if (!qubit_id_exists(a)) {
         PhysicalQubit temp = PhysicalQubit(a);
@@ -248,7 +251,7 @@ void Device::apply_gate(Operation const& op) {
  *
  * @param op
  */
-void Device::apply_swap_check(size_t qid0, size_t qid1) {
+void Device::apply_swap_check(QubitIdType qid0, QubitIdType qid1) {
     auto& q0  = get_physical_qubit(qid0);
     auto& q1  = get_physical_qubit(qid1);
     auto temp = q0.get_logical_qubit();
@@ -264,7 +267,7 @@ void Device::apply_swap_check(size_t qid0, size_t qid1) {
  *
  * @param physicalId
  */
-void Device::apply_single_qubit_gate(size_t physical_id) {
+void Device::apply_single_qubit_gate(QubitIdType physical_id) {
     size_t start_time = _qubit_list[physical_id].get_occupied_time();
     _qubit_list[physical_id].set_occupied_time(start_time + SINGLE_DELAY);
     _qubit_list[physical_id].reset();
@@ -289,7 +292,7 @@ std::vector<std::optional<size_t>> Device::mapping() const {
  *
  * @param assign
  */
-void Device::place(std::vector<size_t> const& assignment) {
+void Device::place(std::vector<QubitIdType> const& assignment) {
     for (size_t i = 0; i < assignment.size(); ++i) {
         assert(_qubit_list[assignment[i]].get_logical_qubit() == std::nullopt);
         _qubit_list[assignment[i]].set_logical_qubit(i);
@@ -304,10 +307,10 @@ void Device::calculate_path() {
     _predecessor.clear();
     _distance.clear();
     _adjacency_matrix.clear();
-    _adjacency_matrix.resize(_num_qubit);
-    for (size_t i = 0; i < _num_qubit; i++) {
-        _adjacency_matrix[i].resize(_num_qubit, _max_dist);
-        for (size_t j = 0; j < _num_qubit; j++) {
+    _adjacency_matrix.resize(get_num_qubits());
+    for (size_t i = 0; i < get_num_qubits(); i++) {
+        _adjacency_matrix[i].resize(get_num_qubits(), _max_dist);
+        for (size_t j = 0; j < get_num_qubits(); j++) {
             if (i == j)
                 _adjacency_matrix[i][j] = 0;
         }
@@ -321,23 +324,23 @@ void Device::calculate_path() {
  *
  */
 void Device::_initialize_floyd_warshall() {
-    _distance.resize(_num_qubit);
-    _predecessor.resize(_num_qubit);
+    _distance.resize(get_num_qubits());
+    _predecessor.resize(get_num_qubits());
 
-    for (size_t i = 0; i < _num_qubit; i++) {
-        _distance[i].resize(_num_qubit);
-        _predecessor[i].resize(_num_qubit, SIZE_MAX);
-        for (size_t j = 0; j < _num_qubit; j++) {
+    for (size_t i = 0; i < get_num_qubits(); i++) {
+        _distance[i].resize(get_num_qubits());
+        _predecessor[i].resize(get_num_qubits(), max_qubit_id);
+        for (size_t j = 0; j < get_num_qubits(); j++) {
             _distance[i][j] = _adjacency_matrix[i][j];
             if (_distance[i][j] != 0 && _distance[i][j] != _max_dist) {
-                _predecessor[i][j] = _qubit_list[i].get_id();
+                _predecessor[i][j] = _qubit_list[gsl::narrow<QubitIdType>(i)].get_id();
             }
         }
     }
 
     spdlog::debug("Predecessor Matrix:");
     for (auto& row : _predecessor) {
-        spdlog::debug("{:5}", fmt::join(row | std::views::transform([](size_t j) { return (j == SIZE_MAX) ? std::string{"/"} : std::to_string(j); }), ""));
+        spdlog::debug("{:5}", fmt::join(row | std::views::transform([](QubitIdType j) { return (j == max_qubit_id) ? std::string{"/"} : std::to_string(j); }), ""));
     }
     spdlog::debug("Distance Matrix:");
     for (auto& row : _distance) {
@@ -353,7 +356,7 @@ void Device::_initialize_floyd_warshall() {
 void Device::_set_weight() {
     assert(_adjacency_matrix.size() == _num_qubit);
     for (size_t i = 0; i < _num_qubit; i++) {
-        for (auto const& adj : _qubit_list[i].get_adjacencies()) {
+        for (auto const& adj : _qubit_list[gsl::narrow<QubitIdType>(i)].get_adjacencies()) {
             _adjacency_matrix[i][adj] = 1;
         }
     }
@@ -380,7 +383,7 @@ void Device::floyd_warshall() {
         spdlog::debug("Predecessor Matrix:");
         for (auto& row : _predecessor) {
             spdlog::debug("{:5}", fmt::join(
-                                      row | std::views::transform([](size_t j) { return (j == SIZE_MAX) ? std::string{"/"} : std::to_string(j); }), ""));
+                                      row | std::views::transform([](auto j) { return (j == max_qubit_id) ? std::string{"/"} : std::to_string(j); }), ""));
         }
         spdlog::debug("Distance Matrix:");
         for (auto& row : _distance) {
@@ -397,15 +400,15 @@ void Device::floyd_warshall() {
  * @param t terminate
  * @return vector<PhyQubit>&
  */
-std::vector<PhysicalQubit> Device::get_path(size_t s, size_t t) const {
+std::vector<PhysicalQubit> Device::get_path(QubitIdType src, QubitIdType dest) const {
     std::vector<PhysicalQubit> path;
-    path.emplace_back(_qubit_list.at(s));
-    if (s == t) return path;
-    size_t new_pred = _predecessor[t][s];
+    path.emplace_back(_qubit_list.at(src));
+    if (src == dest) return path;
+    auto new_pred = _predecessor[dest][src];
     path.emplace_back(new_pred);
     while (true) {
-        new_pred = _predecessor[t][new_pred];
-        if (new_pred == SIZE_MAX) break;
+        new_pred = _predecessor[dest][new_pred];
+        if (new_pred == max_qubit_id) break;
         path.emplace_back(_qubit_list.at(new_pred));
     }
     return path;
@@ -484,7 +487,7 @@ bool Device::read_device(std::string const& filename) {
     for (size_t i = 0; i < adj_list.size(); i++) {
         for (size_t j = 0; j < adj_list[i].size(); j++) {
             if (adj_list[i][j] > i) {
-                add_adjacency(i, adj_list[i][j]);
+                add_adjacency(gsl::narrow<QubitIdType>(i), gsl::narrow<QubitIdType>(adj_list[i][j]));
                 _topology->add_adjacency_info(i, adj_list[i][j], {._time = cx_delay[i][j], ._error = cx_err[i][j]});
             }
         }
@@ -712,7 +715,7 @@ void Device::print_edges(std::vector<size_t> candidates) const {
         size_t cnt = 0;
         for (size_t i = 0; i < _num_qubit; i++) {
             for (auto& q : qubits[i].get_adjacencies()) {
-                if (i < q) {
+                if (std::cmp_less(i, q)) {
                     cnt++;
                     _topology->print_single_edge(i, q);
                 }
@@ -746,7 +749,7 @@ void Device::print_topology() const {
 void Device::print_predecessor() const {
     fmt::println("Predecessor Matrix:");
     for (auto& row : _predecessor) {
-        fmt::println("{:5}", fmt::join(row | std::views::transform([](size_t pred) { return (pred == SIZE_MAX) ? "/" : std::to_string(pred); }), ""));
+        fmt::println("{:5}", fmt::join(row | std::views::transform([](auto pred) { return (pred == max_qubit_id) ? "/" : std::to_string(pred); }), ""));
     }
 }
 
@@ -767,19 +770,19 @@ void Device::print_distance() const {
  * @param s start
  * @param t terminate
  */
-void Device::print_path(size_t source, size_t destination) const {
+void Device::print_path(QubitIdType src, QubitIdType dest) const {
     fmt::println("");
-    for (auto& c : {source, destination}) {
-        if (c >= _num_qubit) {
+    for (auto& c : {src, dest}) {
+        if (std::cmp_greater_equal(c, _num_qubit)) {
             spdlog::error("the maximum qubit id is {}!!", _num_qubit - 1);
             return;
         }
     }
-    std::vector<PhysicalQubit> const& path = get_path(source, destination);
-    if (path.front().get_id() != source && path.back().get_id() != destination)
-        fmt::println("No path between {} and {}", source, destination);
+    std::vector<PhysicalQubit> const& path = get_path(src, dest);
+    if (path.front().get_id() != src && path.back().get_id() != dest)
+        fmt::println("No path between {} and {}", src, dest);
     else {
-        fmt::println("Path from {} to {}:", source, destination);
+        fmt::println("Path from {} to {}:", src, dest);
         size_t cnt = 0;
         for (auto& v : path) {
             constexpr size_t num_cols = 10;
@@ -796,7 +799,7 @@ void Device::print_path(size_t source, size_t destination) const {
 void Device::print_mapping() {
     fmt::println("----------Mapping---------");
     for (size_t i = 0; i < _num_qubit; i++) {
-        fmt::println("{:<5} : {}", i, _qubit_list[i].get_logical_qubit());
+        fmt::println("{:<5} : {}", i, _qubit_list[gsl::narrow<QubitIdType>(i)].get_logical_qubit());
     }
 }
 

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -429,23 +429,23 @@ bool Device::read_device(std::string const& filename) {
     // NOTE - Device name
     while (str == "") {
         std::getline(topo_file, str);
-        str = dvlab::str::strip_spaces(dvlab::str::strip_comments(str));
+        str = dvlab::str::trim_spaces(dvlab::str::trim_comments(str));
     }
     size_t token_end = dvlab::str::str_get_token(str, token, 0, ": ");
     data             = str.substr(token_end + 1);
 
-    _topology->set_name(dvlab::str::strip_spaces(data));
+    _topology->set_name(dvlab::str::trim_spaces(data));
 
     // NOTE - Qubit num
     str = "", token = "", data = "";
     unsigned qbn = 0;
     while (str == "") {
         std::getline(topo_file, str);
-        str = dvlab::str::strip_spaces(dvlab::str::strip_comments(str));
+        str = dvlab::str::trim_spaces(dvlab::str::trim_comments(str));
     }
     token_end = dvlab::str::str_get_token(str, token, 0, ": ");
     data      = str.substr(token_end + 1);
-    data      = dvlab::str::strip_spaces(data);
+    data      = dvlab::str::trim_spaces(data);
     if (!dvlab::str::str_to_u(data, qbn)) {
         spdlog::error("The number of qubit is not a positive integer!!");
         return false;
@@ -456,7 +456,7 @@ bool Device::read_device(std::string const& filename) {
     str = "", token = "", data = "";
     while (str == "") {
         std::getline(topo_file, str);
-        str = dvlab::str::strip_spaces(dvlab::str::strip_comments(str));
+        str = dvlab::str::trim_spaces(dvlab::str::trim_comments(str));
     }
     if (!_parse_gate_set(str)) return false;
 
@@ -464,12 +464,12 @@ bool Device::read_device(std::string const& filename) {
     str = "", token = "", data = "";
     while (str == "") {
         std::getline(topo_file, str);
-        str = dvlab::str::strip_spaces(dvlab::str::strip_comments(str));
+        str = dvlab::str::trim_spaces(dvlab::str::trim_comments(str));
     }
 
     token_end = dvlab::str::str_get_token(str, token, 0, ": ");
     data      = str.substr(token_end + 1);
-    data      = dvlab::str::strip_spaces(data);
+    data      = dvlab::str::trim_spaces(data);
     data      = dvlab::str::remove_brackets(data, '[', ']');
     std::vector<std::vector<float>> cx_err, cx_delay;
     std::vector<std::vector<size_t>> adj_list;
@@ -510,12 +510,12 @@ bool Device::_parse_gate_set(std::string const& gate_set_str) {
     std::string token = "", data = "", gt;
     size_t token_end = dvlab::str::str_get_token(gate_set_str, token, 0, ": ");
     data             = gate_set_str.substr(token_end + 1);
-    data             = dvlab::str::strip_spaces(data);
+    data             = dvlab::str::trim_spaces(data);
     data             = dvlab::str::remove_brackets(data, '{', '}');
     size_t m         = 0;
     while (m < data.size()) {
         m              = dvlab::str::str_get_token(data, gt, m, ',');
-        gt             = dvlab::str::strip_spaces(gt);
+        gt             = dvlab::str::trim_spaces(gt);
         gt             = dvlab::str::tolower_string(gt);
         auto gate_type = str_to_gate_type(gt);
         if (!gate_type.has_value()) {
@@ -544,12 +544,12 @@ bool Device::_parse_info(std::ifstream& f, std::vector<std::vector<float>>& cx_e
         while (str == "") {
             if (f.eof()) break;
             std::getline(f, str);
-            str = dvlab::str::strip_spaces(dvlab::str::strip_comments(str));
+            str = dvlab::str::trim_spaces(dvlab::str::trim_comments(str));
         }
         size_t token_end = dvlab::str::str_get_token(str, token, 0, ": ");
         data             = str.substr(token_end + 1);
 
-        data = dvlab::str::strip_spaces(data);
+        data = dvlab::str::trim_spaces(data);
         if (token == "SGERROR") {
             if (!_parse_singles(data, single_error)) return false;
         } else if (token == "SGTIME") {
@@ -563,7 +563,7 @@ bool Device::_parse_info(std::ifstream& f, std::vector<std::vector<float>>& cx_e
             break;
         }
         std::getline(f, str);
-        str = dvlab::str::strip_spaces(dvlab::str::strip_comments(str));
+        str = dvlab::str::trim_spaces(dvlab::str::trim_comments(str));
     }
 
     return true;
@@ -587,7 +587,7 @@ bool Device::_parse_singles(std::string const& data, std::vector<float>& contain
     std::vector<float> single_fl;
     while (m < str.size()) {
         m   = dvlab::str::str_get_token(str, num, m, ',');
-        num = dvlab::str::strip_spaces(num);
+        num = dvlab::str::trim_spaces(num);
         if (!dvlab::str::str_to_f(num, fl)) {
             spdlog::error("The number `{}` is not a float!!", num);
             return false;
@@ -616,7 +616,7 @@ bool Device::_parse_float_pairs(std::string const& data, std::vector<std::vector
         std::vector<float> single_fl;
         while (m < str.size()) {
             m   = dvlab::str::str_get_token(str, num, m, ',');
-            num = dvlab::str::strip_spaces(num);
+            num = dvlab::str::trim_spaces(num);
             if (!dvlab::str::str_to_f(num, fl)) {
                 spdlog::error("The number `{}` is not a float!!", num);
                 return false;
@@ -647,7 +647,7 @@ bool Device::_parse_size_t_pairs(std::string const& data, std::vector<std::vecto
         std::vector<size_t> single;
         while (m < str.size()) {
             m   = dvlab::str::str_get_token(str, num, m, ',');
-            num = dvlab::str::strip_spaces(num);
+            num = dvlab::str::trim_spaces(num);
             if (!dvlab::str::str_to_u(num, qbn) || qbn >= _num_qubit) {
                 spdlog::error("The number of qubit `{}` is not a positive integer or not in the legal range!!", num);
                 return false;

--- a/src/device/device_cmd.cpp
+++ b/src/device/device_cmd.cpp
@@ -16,6 +16,7 @@
 #include "device/device.hpp"
 #include "device/device_mgr.hpp"
 #include "fmt/core.h"
+#include "qsyn/qsyn_type.hpp"
 
 using namespace dvlab::argparse;
 using dvlab::CmdExecResult;
@@ -169,7 +170,7 @@ dvlab::Command device_graph_print_cmd(qsyn::device::DeviceMgr& device_mgr) {
                     return CmdExecResult::done;
                 }
                 if (parser.parsed("-path")) {
-                    auto qids = parser.get<std::vector<size_t>>("-path");
+                    auto qids = parser.get<std::vector<QubitIdType>>("-path");
                     device_mgr.get()->print_path(qids[0], qids[1]);
                     return CmdExecResult::done;
                 }

--- a/src/device/device_cmd.cpp
+++ b/src/device/device_cmd.cpp
@@ -5,13 +5,14 @@
   Copyright    [ Copyright(c) 2023 DVLab, GIEE, NTU, Taiwan ]
 ****************************************************************************/
 
+#include "./device_cmd.hpp"
+
 #include <spdlog/spdlog.h>
 
 #include <cstddef>
 #include <memory>
 #include <string>
 
-#include "cli/cli.hpp"
 #include "device/device.hpp"
 #include "device/device_mgr.hpp"
 #include "fmt/core.h"

--- a/src/device/device_mgr.hpp
+++ b/src/device/device_mgr.hpp
@@ -11,7 +11,6 @@
 #include <optional>
 #include <vector>
 
-#include "cli/cli.hpp"
 #include "device/device.hpp"
 #include "util/data_structure_manager.hpp"
 

--- a/src/duostra/checker.cpp
+++ b/src/duostra/checker.cpp
@@ -12,6 +12,7 @@
 
 #include "./circuit_topology.hpp"
 #include "qcir/gate_type.hpp"
+#include "qsyn/qsyn_type.hpp"
 #include "util/util.hpp"
 
 using namespace qsyn::qcir;
@@ -30,7 +31,7 @@ namespace qsyn::duostra {
 Checker::Checker(CircuitTopology& topo,
                  Checker::Device& device,
                  std::vector<Checker::Operation> const& ops,
-                 std::vector<size_t> const& assign, bool tqdm)
+                 std::vector<QubitIdType> const& assign, bool tqdm)
     : _topo(&topo), _device(&device), _ops(ops), _tqdm(tqdm) {
     _device->place(assign);
 }
@@ -105,10 +106,10 @@ void Checker::apply_gate(Checker::Operation const& op,
 void Checker::apply_swap(Checker::Operation const& op) {
     DVLAB_ASSERT(op.is_swap(), fmt::format("Gate type {} in apply_swap is not allowed!!", op.get_type_str()));
 
-    size_t q0_idx = get<0>(op.get_qubits());
-    size_t q1_idx = get<1>(op.get_qubits());
-    auto& q0      = _device->get_physical_qubit(q0_idx);
-    auto& q1      = _device->get_physical_qubit(q1_idx);
+    auto q0_idx = get<0>(op.get_qubits());
+    auto q1_idx = get<1>(op.get_qubits());
+    auto& q0    = _device->get_physical_qubit(q0_idx);
+    auto& q1    = _device->get_physical_qubit(q1_idx);
     apply_gate(op, q0, q1);
 
     // swap
@@ -127,10 +128,10 @@ void Checker::apply_swap(Checker::Operation const& op) {
  */
 bool Checker::apply_cx(Operation const& op, Gate const& gate) {
     DVLAB_ASSERT(op.is_cx() || op.is_cz(), fmt::format("Gate type {} in apply_cx is not allowed!!", op.get_type_str()));
-    size_t q0_idx = get<0>(op.get_qubits());
-    size_t q1_idx = get<1>(op.get_qubits());
-    auto& q0      = _device->get_physical_qubit(q0_idx);
-    auto& q1      = _device->get_physical_qubit(q1_idx);
+    auto q0_idx = get<0>(op.get_qubits());
+    auto q1_idx = get<1>(op.get_qubits());
+    auto& q0    = _device->get_physical_qubit(q0_idx);
+    auto& q1    = _device->get_physical_qubit(q1_idx);
 
     auto topo_0 = q0.get_logical_qubit();
     auto topo_1 = q1.get_logical_qubit();
@@ -164,10 +165,10 @@ bool Checker::apply_single(Operation const& op, Gate const& gate) {
         !op.is_swap() && !op.is_cx() && !op.is_cz(),
         fmt::format("Gate type {} in apply_single is not allowed!!", op.get_type_str()));
 
-    size_t q0_idx = get<0>(op.get_qubits());
+    auto q0_idx = get<0>(op.get_qubits());
 
     DVLAB_ASSERT(
-        get<1>(op.get_qubits()) == SIZE_MAX,
+        !op.is_double_qubit_gate(),
         fmt::format("Single gate {} has no null second qubit", gate.get_id()));
 
     auto& q0 = _device->get_physical_qubit(q0_idx);

--- a/src/duostra/checker.hpp
+++ b/src/duostra/checker.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "device/device.hpp"
+#include "qsyn/qsyn_type.hpp"
 
 namespace qsyn::duostra {
 
@@ -20,7 +21,10 @@ public:
     using Device        = qsyn::device::Device;
     using Operation     = qsyn::device::Operation;
     using PhysicalQubit = qsyn::device::PhysicalQubit;
-    Checker(CircuitTopology&, Device&, std::vector<Operation> const& ops, std::vector<size_t> const&, bool = true);
+    Checker(CircuitTopology& topo,
+            Checker::Device& device,
+            std::vector<Checker::Operation> const& ops,
+            std::vector<QubitIdType> const& assign, bool tqdm = true);
 
     size_t get_cycle(Operation const& op);
 

--- a/src/duostra/circuit_topology.hpp
+++ b/src/duostra/circuit_topology.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "qcir/qcir_gate.hpp"
+#include "qsyn/qsyn_type.hpp"
 #include "util/phase.hpp"
 
 namespace qsyn::duostra {
@@ -48,15 +49,15 @@ public:
     bool is_last_gate() const { return _nexts.empty(); }
 
     bool is_swap() const { return _type == qcir::GateRotationCategory::swap; }
-    bool is_cx() const { return _type == qcir::GateRotationCategory::px && _phase == dvlab::Phase(1) && std::get<1>(_qubits) != SIZE_MAX; }
-    bool is_cz() const { return _type == qcir::GateRotationCategory::pz && _phase == dvlab::Phase(1) && std::get<1>(_qubits) != SIZE_MAX; }
+    bool is_cx() const { return _type == qcir::GateRotationCategory::px && _phase == dvlab::Phase(1) && std::get<1>(_qubits) != max_qubit_id; }
+    bool is_cz() const { return _type == qcir::GateRotationCategory::pz && _phase == dvlab::Phase(1) && std::get<1>(_qubits) != max_qubit_id; }
 
 private:
     size_t _id;
     qcir::GateRotationCategory _type;
     dvlab::Phase _phase;  // For saving phase information
     bool _swap;           // qubits is swapped for duostra
-    std::tuple<size_t, size_t> _qubits;
+    std::tuple<QubitIdType, QubitIdType> _qubits;
     std::vector<size_t> _prevs;
     std::vector<size_t> _nexts;
 };

--- a/src/duostra/mapping_eqv_checker.cpp
+++ b/src/duostra/mapping_eqv_checker.cpp
@@ -11,6 +11,7 @@
 #include "qcir/qcir.hpp"
 #include "qcir/qcir_gate.hpp"
 #include "qcir/qcir_qubit.hpp"
+#include "qsyn/qsyn_type.hpp"
 
 using namespace qsyn::qcir;
 
@@ -25,7 +26,7 @@ namespace qsyn::duostra {
  * @param init
  * @param reverse check reversily if true
  */
-MappingEquivalenceChecker::MappingEquivalenceChecker(QCir* phy, QCir* log, Device dev, std::vector<size_t> init, bool reverse) : _physical(phy), _logical(log), _device(std::move(dev)), _reverse(reverse) {
+MappingEquivalenceChecker::MappingEquivalenceChecker(QCir* phy, QCir* log, Device dev, std::vector<QubitIdType> init, bool reverse) : _physical(phy), _logical(log), _device(std::move(dev)), _reverse(reverse) {
     if (init.empty()) {
         auto placer = get_placer();
         init        = placer->place_and_assign(_device);

--- a/src/duostra/mapping_eqv_checker.hpp
+++ b/src/duostra/mapping_eqv_checker.hpp
@@ -20,7 +20,7 @@ namespace qcir {
 
 class QCir;
 class QCirGate;
-class QubitInfo;
+struct QubitInfo;
 
 }  // namespace qcir
 

--- a/src/duostra/mapping_eqv_checker.hpp
+++ b/src/duostra/mapping_eqv_checker.hpp
@@ -29,7 +29,7 @@ namespace duostra {
 class MappingEquivalenceChecker {
 public:
     using Device = qsyn::device::Device;
-    MappingEquivalenceChecker(qcir::QCir*, qcir::QCir*, Device, std::vector<size_t> = {}, bool = false);
+    MappingEquivalenceChecker(qcir::QCir*, qcir::QCir*, Device, std::vector<QubitIdType> = {}, bool = false);
 
     bool check();
     bool is_swap(qcir::QCirGate*);

--- a/src/duostra/placer.cpp
+++ b/src/duostra/placer.cpp
@@ -13,6 +13,7 @@
 
 #include "./duostra.hpp"
 #include "device/device.hpp"
+#include "qsyn/qsyn_type.hpp"
 #include "util/util.hpp"
 
 namespace qsyn::duostra {
@@ -40,7 +41,7 @@ std::unique_ptr<BasePlacer> get_placer() {
  *
  * @param device
  */
-std::vector<size_t> BasePlacer::place_and_assign(Device& device) {
+std::vector<QubitIdType> BasePlacer::place_and_assign(Device& device) {
     auto assign = _place(device);
     device.place(assign);
     return assign;
@@ -54,8 +55,8 @@ std::vector<size_t> BasePlacer::place_and_assign(Device& device) {
  * @param device
  * @return vector<size_t>
  */
-std::vector<size_t> RandomPlacer::_place(Device& device) const {
-    std::vector<size_t> assign;
+std::vector<QubitIdType> RandomPlacer::_place(Device& device) const {
+    std::vector<QubitIdType> assign;
     for (size_t i = 0; i < device.get_num_qubits(); ++i)
         assign.emplace_back(i);
 
@@ -72,8 +73,8 @@ std::vector<size_t> RandomPlacer::_place(Device& device) const {
  * @param device
  * @return vector<size_t>
  */
-std::vector<size_t> StaticPlacer::_place(Device& device) const {
-    std::vector<size_t> assign;
+std::vector<QubitIdType> StaticPlacer::_place(Device& device) const {
+    std::vector<QubitIdType> assign;
     for (size_t i = 0; i < device.get_num_qubits(); ++i)
         assign.emplace_back(i);
 
@@ -88,8 +89,8 @@ std::vector<size_t> StaticPlacer::_place(Device& device) const {
  * @param device
  * @return vector<size_t>
  */
-std::vector<size_t> DFSPlacer::_place(Device& device) const {
-    std::vector<size_t> assign;
+std::vector<QubitIdType> DFSPlacer::_place(Device& device) const {
+    std::vector<QubitIdType> assign;
     std::vector<bool> qubit_mark(device.get_num_qubits(), false);
     _dfs_device(0, device, assign, qubit_mark);
     assert(assign.size() == device.get_num_qubits());
@@ -104,7 +105,7 @@ std::vector<size_t> DFSPlacer::_place(Device& device) const {
  * @param assign
  * @param qubitMark
  */
-void DFSPlacer::_dfs_device(size_t current, Device& device, std::vector<size_t>& assign, std::vector<bool>& qubit_marks) const {
+void DFSPlacer::_dfs_device(QubitIdType current, Device& device, std::vector<QubitIdType>& assign, std::vector<bool>& qubit_marks) const {
     if (qubit_marks[current]) {
         std::cout << current << std::endl;
     }
@@ -113,7 +114,7 @@ void DFSPlacer::_dfs_device(size_t current, Device& device, std::vector<size_t>&
     assign.emplace_back(current);
 
     auto const& q = device.get_physical_qubit(current);
-    std::vector<size_t> adjacency_waitlist;
+    std::vector<QubitIdType> adjacency_waitlist;
 
     for (auto& adj : q.get_adjacencies()) {
         // already marked
@@ -128,7 +129,7 @@ void DFSPlacer::_dfs_device(size_t current, Device& device, std::vector<size_t>&
     }
 
     for (size_t i = 0; i < adjacency_waitlist.size(); ++i) {
-        size_t adj = adjacency_waitlist[i];
+        auto adj = adjacency_waitlist[i];
         if (qubit_marks[adj])
             continue;
         _dfs_device(adj, device, assign, qubit_marks);

--- a/src/duostra/placer.hpp
+++ b/src/duostra/placer.hpp
@@ -12,6 +12,8 @@
 #include <random>
 #include <vector>
 
+#include "qsyn/qsyn_type.hpp"
+
 namespace qsyn::device {
 class Device;
 }
@@ -24,10 +26,10 @@ public:
     BasePlacer() {}
     virtual ~BasePlacer() = default;
 
-    std::vector<size_t> place_and_assign(Device &);
+    std::vector<QubitIdType> place_and_assign(Device&);
 
 protected:
-    virtual std::vector<size_t> _place(Device &) const = 0;
+    virtual std::vector<QubitIdType> _place(Device&) const = 0;
 };
 
 class RandomPlacer : public BasePlacer {
@@ -36,7 +38,7 @@ public:
     ~RandomPlacer() override = default;
 
 protected:
-    std::vector<size_t> _place(Device & /*unused*/) const override;
+    std::vector<QubitIdType> _place(Device& /*unused*/) const override;
 };
 
 class StaticPlacer : public BasePlacer {
@@ -45,7 +47,7 @@ public:
     ~StaticPlacer() override = default;
 
 protected:
-    std::vector<size_t> _place(Device & /*unused*/) const override;
+    std::vector<QubitIdType> _place(Device& /*unused*/) const override;
 };
 
 class DFSPlacer : public BasePlacer {
@@ -54,10 +56,10 @@ public:
     ~DFSPlacer() override = default;
 
 protected:
-    std::vector<size_t> _place(Device & /*unused*/) const override;
+    std::vector<QubitIdType> _place(Device& /*unused*/) const override;
 
 private:
-    void _dfs_device(size_t, Device &, std::vector<size_t> &, std::vector<bool> &) const;
+    void _dfs_device(QubitIdType current, Device& device, std::vector<QubitIdType>& assign, std::vector<bool>& qubit_marks) const;
 };
 
 std::unique_ptr<BasePlacer> get_placer();

--- a/src/duostra/router.cpp
+++ b/src/duostra/router.cpp
@@ -43,12 +43,12 @@ AStarNode::AStarNode(size_t cost, size_t id, bool source)
  * @param orient
  */
 Router::Router(Device&& device, Router::CostStrategyType cost_strategy, MinMaxOptionType tie_breaking_strategy)
-    : _greedy_type(_greedy_type = cost_strategy == CostStrategyType::start),
-      _duostra(DuostraConfig::ROUTER_TYPE == RouterType::duostra),
-      _tie_breaking_strategy(tie_breaking_strategy),
-      _apsp(DuostraConfig::ROUTER_TYPE == RouterType::shortest_path || cost_strategy == CostStrategyType::end),
+    : _tie_breaking_strategy(tie_breaking_strategy),
       _device(device),
-      _logical_to_physical({}) {
+      _logical_to_physical({}),
+      _apsp(DuostraConfig::ROUTER_TYPE == RouterType::shortest_path || cost_strategy == CostStrategyType::end),
+      _duostra(DuostraConfig::ROUTER_TYPE == RouterType::duostra),
+      _greedy_type(_greedy_type = cost_strategy == CostStrategyType::start) {
     _initialize();
 }
 

--- a/src/duostra/router.hpp
+++ b/src/duostra/router.hpp
@@ -13,6 +13,7 @@
 
 #include "./duostra_def.hpp"
 #include "device/device.hpp"
+#include "qsyn/qsyn_type.hpp"
 
 namespace qsyn::duostra {
 
@@ -21,15 +22,15 @@ class Gate;
 class AStarNode {
 public:
     friend class AStarComp;
-    AStarNode(size_t, size_t, bool);
+    AStarNode(size_t cost, QubitIdType id, bool source);
 
-    bool get_source() const { return _source; }
-    size_t get_id() const { return _id; }
-    size_t get_cost() const { return _estimated_cost; }
+    auto get_source() const { return _source; }
+    auto get_id() const { return _id; }
+    auto get_cost() const { return _estimated_cost; }
 
 private:
     size_t _estimated_cost;
-    size_t _id;
+    QubitIdType _id;
     bool _source;  // false q0 propagate, true q1 propagate
 };
 
@@ -54,30 +55,30 @@ public:
 
     std::unique_ptr<Router> clone() const;
 
-    Device& get_device() { return _device; }
-    Device const& get_device() const { return _device; }
+    auto& get_device() { return _device; }
+    auto const& get_device() const { return _device; }
 
     size_t get_gate_cost(Gate const&, MinMaxOptionType min_max, size_t apsp_coeff);
     bool is_executable(Gate const&);
 
     // Main Router function
-    Operation execute_single(qcir::GateRotationCategory, dvlab::Phase, size_t);
-    std::vector<Operation> duostra_routing(Gate const& gate, std::tuple<size_t, size_t>, MinMaxOptionType tie_breaking_strategy, bool swapped);
-    std::vector<Operation> apsp_routing(Gate const& gate, std::tuple<size_t, size_t>, MinMaxOptionType tie_breaking_strategy, bool swapped);
+    Operation execute_single(qcir::GateRotationCategory gate, dvlab::Phase phase, QubitIdType q);
+    std::vector<Operation> duostra_routing(Gate const& gate, std::tuple<QubitIdType, QubitIdType> qubit_pair, MinMaxOptionType tie_breaking_strategy, bool swapped);
+    std::vector<Operation> apsp_routing(Gate const& gate, std::tuple<QubitIdType, QubitIdType> qs, MinMaxOptionType tie_breaking_strategy, bool swapped);
     std::vector<Operation> assign_gate(Gate const&);
 
 private:
     MinMaxOptionType _tie_breaking_strategy;
     Device _device;
-    std::vector<size_t> _logical_to_physical;
+    std::vector<QubitIdType> _logical_to_physical;
     bool _apsp : 1;
     bool _duostra : 1;
     bool _greedy_type : 1;
 
     void _initialize();
-    std::tuple<size_t, size_t> _get_physical_qubits(Gate const& gate) const;
+    std::tuple<QubitIdType, QubitIdType> _get_physical_qubits(Gate const& gate) const;
 
-    std::tuple<bool, size_t> _touch_adjacency(PhysicalQubit& qubit, PriorityQueue& pq, bool source);  // return <if touch target, target id>, swtch: false q0 propagate, true q1 propagate
+    std::tuple<bool, QubitIdType> _touch_adjacency(PhysicalQubit& qubit, PriorityQueue& pq, bool source);  // return <if touch target, target id>, swtch: false q0 propagate, true q1 propagate
     std::vector<Operation> _traceback(Gate const& gate, PhysicalQubit& q0, PhysicalQubit& q1, PhysicalQubit& t0, PhysicalQubit& t1, bool swap_ids, bool swapped);
 };
 

--- a/src/qcir/optimizer/basic_optimization.cpp
+++ b/src/qcir/optimizer/basic_optimization.cpp
@@ -443,7 +443,6 @@ bool Optimizer::_replace_cx_and_cz_with_s_and_cx(QubitIdType t1, QubitIdType t2)
  *
  */
 void Optimizer::_add_cz(QubitIdType t1, QubitIdType t2, bool do_minimize_czs) {
-    size_t ctrl = -1, targ = -1;
     bool found_match  = false;
     QCirGate* targ_cz = nullptr;
 

--- a/src/qcir/qcir.cpp
+++ b/src/qcir/qcir.cpp
@@ -70,7 +70,7 @@ QCirGate *QCir::get_gate(size_t id) const {
  * @param id
  * @return QCirQubit
  */
-QCirQubit *QCir::get_qubit(size_t id) const {
+QCirQubit *QCir::get_qubit(QubitIdType id) const {
     for (size_t i = 0; i < _qubits.size(); i++) {
         if (_qubits[i]->get_id() == id)
             return _qubits[i];

--- a/src/qcir/qcir.hpp
+++ b/src/qcir/qcir.hpp
@@ -92,7 +92,7 @@ public:
     std::vector<QCirGate*> const& get_topologically_ordered_gates() const { return _topological_order; }
     std::vector<QCirGate*> const& get_gates() const { return _qgates; }
     QCirGate* get_gate(size_t gid) const;
-    QCirQubit* get_qubit(size_t qid) const;
+    QCirQubit* get_qubit(QubitIdType qid) const;
     std::string get_filename() const { return _filename; }
     std::vector<std::string> const& get_procedures() const { return _procedures; }
 
@@ -100,7 +100,6 @@ public:
     void add_procedures(std::vector<std::string> const& ps) { _procedures.insert(_procedures.end(), ps.begin(), ps.end()); }
     void add_procedure(std::string const& p) { _procedures.emplace_back(p); }
 
-    //
     void reset();
     QCir* compose(QCir const& other);
     QCir* tensor_product(QCir const& other);

--- a/src/qcir/qcir_cmd.cpp
+++ b/src/qcir/qcir_cmd.cpp
@@ -91,7 +91,7 @@ dvlab::Command qcir_mgr_reset_cmd(QCirMgr& qcir_mgr) {
                 parser.description("reset QCirMgr");
             },
             [&](ArgumentParser const&) {
-                qcir_mgr.reset();
+                qcir_mgr.clear();
                 return CmdExecResult::done;
             }};
 }

--- a/src/qcir/qcir_gate.cpp
+++ b/src/qcir/qcir_gate.cpp
@@ -15,7 +15,6 @@
 #include <string>
 #include <type_traits>
 
-#include "cli/cli.hpp"
 #include "qcir/gate_type.hpp"
 #include "util/util.hpp"
 

--- a/src/qcir/qcir_gate.cpp
+++ b/src/qcir/qcir_gate.cpp
@@ -16,6 +16,7 @@
 #include <type_traits>
 
 #include "qcir/gate_type.hpp"
+#include "qsyn/qsyn_type.hpp"
 #include "util/util.hpp"
 
 namespace qsyn::qcir {
@@ -79,7 +80,7 @@ size_t QCirGate::get_delay() const {
  * @param qubit
  * @return BitInfo
  */
-QubitInfo QCirGate::get_qubit(size_t qubit) const {
+QubitInfo QCirGate::get_qubit(QubitIdType qubit) const {
     for (size_t i = 0; i < _qubits.size(); i++) {
         if (_qubits[i]._qubit == qubit)
             return _qubits[i];

--- a/src/qcir/qcir_gate.hpp
+++ b/src/qcir/qcir_gate.hpp
@@ -67,7 +67,7 @@ public:
     dvlab::Phase get_phase() const { return _phase; }
     std::vector<QubitInfo> const& get_qubits() const { return _qubits; }
     void set_qubits(std::vector<QubitInfo> const& qubits) { _qubits = qubits; }
-    QubitInfo get_qubit(size_t qubit) const;
+    QubitInfo get_qubit(QubitIdType qubit) const;
     size_t get_num_qubits() const { return _qubits.size(); }
     QubitInfo get_targets() const { return _qubits[_qubits.size() - 1]; }
     QubitInfo get_control() const { return _qubits[0]; }

--- a/src/qcir/qcir_gate.hpp
+++ b/src/qcir/qcir_gate.hpp
@@ -11,7 +11,6 @@
 #include <string>
 #include <unordered_map>
 
-#include "cli/cli.hpp"
 #include "qcir/gate_type.hpp"
 #include "qsyn/qsyn_type.hpp"
 #include "util/phase.hpp"

--- a/src/qcir/qcir_reader.cpp
+++ b/src/qcir/qcir_reader.cpp
@@ -94,8 +94,8 @@ bool QCir::read_qasm(std::string const& filename) {
     add_qubits(nqubit);
     getline(qasm_file, str);
     while (getline(qasm_file, str)) {
-        str = dvlab::str::strip_comments(str);
-        str = dvlab::str::strip_spaces(str);
+        str = dvlab::str::trim_comments(str);
+        str = dvlab::str::trim_spaces(str);
         if (str == "") continue;
         std::string type;
         size_t type_end       = str_get_token(str, type);

--- a/src/qsyn/qcir_to_tensor.cpp
+++ b/src/qsyn/qcir_to_tensor.cpp
@@ -16,13 +16,14 @@
 #include "qcir/gate_type.hpp"
 #include "qcir/qcir.hpp"
 #include "qcir/qcir_qubit.hpp"
+#include "qsyn/qsyn_type.hpp"
 #include "tensor/qtensor.hpp"
 
 extern bool stop_requested();
 
 namespace qsyn {
 
-using Qubit2TensorPinMap = std::unordered_map<size_t, std::pair<size_t, size_t>>;
+using Qubit2TensorPinMap = std::unordered_map<QubitIdType, std::pair<size_t, size_t>>;
 
 using qsyn::tensor::QTensor;
 

--- a/src/qsyn/qcir_to_zxgraph.cpp
+++ b/src/qsyn/qcir_to_zxgraph.cpp
@@ -361,29 +361,6 @@ ZXGraph create_cz_zx_form(QCirGate* gate) {
     return g;
 }
 
-// Y Gate
-// NOTE - Cannot use mapSingleQubitGate
-
-/**
- * @brief Get ZXGraph of Y = iXZ
- *
- * @return ZXGraph
- */
-ZXGraph create_y_zx_form(QCirGate* gate) {
-    ZXGraph g;
-    auto qubit = gate->get_qubits()[0]._qubit;
-
-    ZXVertex* in  = g.add_input(qubit);
-    ZXVertex* x   = g.add_vertex(qubit, VertexType::x, dvlab::Phase(1));
-    ZXVertex* z   = g.add_vertex(qubit, VertexType::z, dvlab::Phase(1));
-    ZXVertex* out = g.add_output(qubit);
-    g.add_edge(in, x, EdgeType::simple);
-    g.add_edge(x, z, EdgeType::simple);
-    g.add_edge(z, out, EdgeType::simple);
-
-    return g;
-}
-
 /**
  * @brief Get ZXGraph of SY = S。SX。Sdg
  *

--- a/src/qsyn/qsyn_main.cpp
+++ b/src/qsyn/qsyn_main.cpp
@@ -10,6 +10,7 @@
 
 #include <chrono>
 #include <csignal>
+#include <type_traits>
 
 #include "./conversion_cmd.hpp"
 #include "cli/cli.hpp"
@@ -111,12 +112,7 @@ int main(int argc, char** argv) {
 
     dvlab::utils::Usage::reset();
 
-    auto status = dvlab::CmdExecResult::done;
+    auto result = cli.start_interactive();
 
-    while (status != dvlab::CmdExecResult::quit) {  // until "quit" or command error
-        status = cli.execute_one_line();
-        fmt::print("\n");
-    }
-
-    return 0;
+    return static_cast<std::underlying_type_t<dvlab::CmdExecResult>>(result);
 }

--- a/src/qsyn/qsyn_type.hpp
+++ b/src/qsyn/qsyn_type.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <limits>
 #include <vector>
 
 namespace dvlab {
@@ -14,7 +15,9 @@ class Phase;
 }
 
 namespace qsyn {
-using QubitIdType = int;
-using QubitIdList = std::vector<QubitIdType>;
-using Phase       = dvlab::Phase;
+using QubitIdType           = int;
+constexpr auto max_qubit_id = std::numeric_limits<QubitIdType>::max();
+constexpr auto min_qubit_id = std::numeric_limits<QubitIdType>::min();
+using QubitIdList           = std::vector<QubitIdType>;
+using Phase                 = dvlab::Phase;
 }  // namespace qsyn

--- a/src/tensor/tensor_cmd.cpp
+++ b/src/tensor/tensor_cmd.cpp
@@ -33,7 +33,7 @@ Command tensor_mgr_reset_cmd(TensorMgr& tensor_mgr) {
                 parser.description("reset the tensor manager");
             },
             [&](ArgumentParser const& /*parser*/) {
-                tensor_mgr.reset();
+                tensor_mgr.clear();
                 return CmdExecResult::done;
             }};
 }

--- a/src/util/boolean_matrix.cpp
+++ b/src/util/boolean_matrix.cpp
@@ -197,7 +197,7 @@ size_t BooleanMatrix::gaussian_elimination_skip(size_t block_size, bool do_fully
         }
     };
 
-    auto clear_all_1s_in_column = [this, get_sub_vec, track](size_t pivot_row_idx, size_t col_idx, auto row_range) {
+    auto clear_all_1s_in_column = [this, track](size_t pivot_row_idx, size_t col_idx, auto row_range) {
         auto rows_to_clear = row_range | std::views::filter([this, col_idx](size_t row_idx) -> bool {
                                  return _matrix[row_idx][col_idx] == 1;
                              });

--- a/src/util/data_structure_manager.hpp
+++ b/src/util/data_structure_manager.hpp
@@ -56,7 +56,7 @@ public:
         a.swap(b);
     }
 
-    void reset() {
+    void clear() {
         _next_id    = 0;
         _focused_id = 0;
         _list.clear();

--- a/src/util/dvlab_string.cpp
+++ b/src/util/dvlab_string.cpp
@@ -5,8 +5,6 @@
   Copyright    [ Copyright(c) 2023 DVLab, GIEE, NTU, Taiwan ]
 ****************************************************************************/
 
-#include <fmt/core.h>
-
 #include <cassert>
 #include <cctype>
 #include <concepts>
@@ -22,102 +20,11 @@ namespace dvlab {
 namespace str {
 
 /**
- * @brief
- *
- * @param input the string to strip quotes
- * @param output if the function returns true, output the stripped string; else output the same string as input.
- * @return true if quotation marks are paired;
- * @return false if quotation marks are unpaired.
- */
-std::optional<std::string> strip_quotes(std::string const& input) {
-    if (input == "") {
-        return input;
-    }
-
-    std::string output = input;
-
-    std::vector<std::string> outside;
-    std::vector<std::string> inside;
-
-    auto find_quote = [&output](char quote) -> size_t {
-        size_t pos = 0;
-        pos        = output.find_first_of(quote);
-        if (pos == std::string::npos) return pos;
-        // if the quote is after a backslash, it should be read verbatim, so we need to skip it.
-        while (pos != 0 && output[pos - 1] == '\\') {
-            pos = output.find_first_of(quote, pos + 1);
-            if (pos == std::string::npos) return pos;
-        }
-        return pos;
-    };
-
-    while (output.size()) {
-        size_t pos = std::min(find_quote('\"'), find_quote('\''));
-
-        outside.emplace_back(output.substr(0, pos));
-        if (pos == std::string::npos) break;
-
-        char delim = output[pos];
-
-        output = output.substr(pos + 1);
-        if (pos != std::string::npos) {
-            size_t closing_quote_pos = find_quote(delim);
-
-            if (closing_quote_pos == std::string::npos) {
-                return std::nullopt;
-            }
-
-            inside.emplace_back(output.substr(0, closing_quote_pos));
-            output = output.substr(closing_quote_pos + 1);
-        }
-    }
-
-    // 2. inside  ' ' --> "\ "
-    //    both side \' --> ' , \" --> "
-
-    auto remove_quotes = [](std::vector<std::string>& strs) {
-        for (auto& str : strs) {
-            size_t pos = 0;
-            while ((pos = str.find("\\\"", pos)) != std::string::npos) {
-                str = str.substr(0, pos) + str.substr(pos + 1);
-            }
-            pos = 0;
-            while ((pos = str.find("\\\'", pos)) != std::string::npos) {
-                str = str.substr(0, pos) + str.substr(pos + 1);
-            }
-        }
-    };
-
-    for (auto& str : inside) {
-        for (size_t i = 0; i < str.size(); ++i) {
-            if (str[i] == ' ') {
-                str.insert(i, "\\");
-                i++;
-            }
-        }
-    }
-
-    remove_quotes(outside);
-    remove_quotes(inside);
-
-    // 3. recombine
-    output = "";
-    for (size_t i = 0; i < outside.size(); ++i) {
-        output += outside[i];
-        if (i < inside.size()) {
-            output += inside[i];
-        }
-    }
-
-    return output;
-}
-
-/**
  * @brief strip the leading whitespaces of a string
  *
  * @param str
  */
-std::string strip_leading_spaces(std::string const& str) {
+std::string trim_leading_spaces(std::string const& str) {
     size_t start = str.find_first_not_of(" \t\n\v\f\r");
     if (start == std::string::npos) return "";
     return str.substr(start);
@@ -128,23 +35,11 @@ std::string strip_leading_spaces(std::string const& str) {
  *
  * @param str
  */
-std::string strip_spaces(std::string const& str) {
+std::string trim_spaces(std::string const& str) {
     size_t start = str.find_first_not_of(" \t\n\v\f\r");
     size_t end   = str.find_last_not_of(" \t\n\v\f\r");
     if (start == std::string::npos && end == std::string::npos) return "";
     return str.substr(start, end + 1 - start);
-}
-
-/**
- * @brief Return true if the `pos`th character in `str` is escaped, i.e., preceded by a single backslash
- *
- * @param str
- * @param pos
- * @return true
- * @return false
- */
-bool is_escaped_char(std::string const& str, size_t pos) {
-    return pos > 0 && str[pos - 1] == '\\' && (pos == 1 || str[pos - 2] != '\\');
 }
 
 /**
@@ -158,7 +53,7 @@ bool is_escaped_char(std::string const& str, size_t pos) {
 std::string remove_brackets(std::string const& str, char const left, char const right) {
     size_t last_found  = str.find_last_of(right);
     size_t first_found = str.find_first_of(left);
-    return strip_spaces(str.substr(first_found + 1, last_found - first_found - 1));
+    return trim_spaces(str.substr(first_found + 1, last_found - first_found - 1));
 }
 
 // Parse the string "str" for the token "tok", beginning at position "pos",

--- a/src/util/text_format.cpp
+++ b/src/util/text_format.cpp
@@ -13,6 +13,9 @@
 #include <ranges>
 
 #include "./util.hpp"
+#include "fmt/color.h"
+#include "fmt/core.h"
+#include "util/terminal_attributes.hpp"
 
 namespace fs = std::filesystem;
 
@@ -21,8 +24,8 @@ namespace dvlab {
 namespace fmt_ext {
 
 fmt::text_style ls_color(fs::path const& path) {
-    static auto const ls_color = [](std::string const& key) -> fmt::text_style {
-        static auto ls_color_map = std::invoke([]() {
+    static auto const ls_color_internal = [](std::string const& key) -> fmt::text_style {
+        static auto const ls_color_map = std::invoke([]() {
             std::unordered_map<std::string, fmt::text_style> map;
             char const* const ls_colors_str = getenv("LS_COLORS");
             if (ls_colors_str == nullptr) return map;
@@ -37,13 +40,13 @@ fmt::text_style ls_color(fs::path const& path) {
                     values.begin(), values.end(),
                     fmt::text_style{},
                     std::bit_or<>{},
-                    [](std::string const& str) {
-                        uint8_t tmp;
-                        if (!dvlab::str::str_to_num(str, tmp) || tmp == 0) return fmt::text_style{};
-                        if (tmp >= 30 && tmp <= 37) return fmt::fg(fmt::terminal_color{tmp});
-                        if (tmp >= 90 && tmp <= 97) return fmt::fg(fmt::terminal_color{tmp});
-                        if (tmp >= 40 && tmp <= 47) return fmt::bg(fmt::terminal_color{tmp});
-                        if (tmp >= 100 && tmp <= 107) return fmt::bg(fmt::terminal_color{tmp});
+                    [&](std::string const& str) {
+                        size_t tmp;
+                        if (!dvlab::str::str_to_num<size_t>(str, tmp) || tmp == 0) return fmt::text_style{};
+                        if (tmp >= 30 && tmp <= 37) return fmt::fg(fmt::terminal_color{gsl::narrow<uint8_t>(tmp)});
+                        if (tmp >= 90 && tmp <= 97) return fmt::fg(fmt::terminal_color{gsl::narrow<uint8_t>(tmp)});
+                        if (tmp >= 40 && tmp <= 47) return fmt::bg(fmt::terminal_color{gsl::narrow<uint8_t>(tmp)});
+                        if (tmp >= 100 && tmp <= 107) return fmt::bg(fmt::terminal_color{gsl::narrow<uint8_t>(tmp)});
                         assert(tmp >= 0 && tmp <= 7);
                         return fmt::text_style{fmt::emphasis{gsl::narrow<uint8_t>(1 << (tmp - 1))}};
                     });
@@ -72,47 +75,47 @@ fmt::text_style ls_color(fs::path const& path) {
             bool is_sticky         = (permissions & perms::sticky_bit) != perms::none;
             bool is_other_writable = (permissions & perms::others_write) != perms::none;
             if (is_sticky) {
-                return is_other_writable ? ls_color("tw") : ls_color("st");
+                return is_other_writable ? ls_color_internal("tw") : ls_color_internal("st");
             }
-            return is_other_writable ? ls_color("ow") : ls_color("di");
+            return is_other_writable ? ls_color_internal("ow") : ls_color_internal("di");
         }
         case file_type::symlink: {
             return (fs::read_symlink(path) != "")
-                       ? ls_color("ln")
-                       : ls_color("or");
+                       ? ls_color_internal("ln")
+                       : ls_color_internal("or");
         }
         // NOTE - omitting multi-hardlinks (mh) -- don't know how to detect it...
         case file_type::fifo:
-            return ls_color("pi");
+            return ls_color_internal("pi");
         case file_type::socket:
-            return ls_color("so");
+            return ls_color_internal("so");
         // NOTE - omitting doors (do) -- basically obsolete
         case file_type::block:
-            return ls_color("bd");
+            return ls_color_internal("bd");
         case file_type::character:
-            return ls_color("cd");
+            return ls_color_internal("cd");
         case file_type::not_found:
-            return ls_color("mi");
+            return ls_color_internal("mi");
         default:
             break;
     }
 
     if ((permissions & perms::set_uid) != perms::none) {
-        return ls_color("su");
+        return ls_color_internal("su");
     }
 
     if ((permissions & perms::set_gid) != perms::none) {
-        return ls_color("sg");
+        return ls_color_internal("sg");
     }
 
     // NOTE - omitting files with capacities
 
     // executable files
     if ((permissions & (perms::owner_exec | perms::group_exec | perms::others_exec)) != perms::none) {
-        return ls_color("ex");
+        return ls_color_internal("ex");
     }
 
-    return ls_color("*" + path.extension().string());
+    return ls_color_internal("*" + path.extension().string());
 }
 
 }  // namespace fmt_ext

--- a/src/util/trie.cpp
+++ b/src/util/trie.cpp
@@ -9,6 +9,8 @@
 
 #include <cassert>
 
+#include "fmt/core.h"
+
 namespace dvlab {
 
 namespace utils {

--- a/src/util/util.hpp
+++ b/src/util/util.hpp
@@ -116,17 +116,15 @@ size_t ansi_token_size(F const& fn) {
     return fn("").size();
 }
 
-std::optional<std::string> strip_quotes(std::string const& input);
-std::string strip_leading_spaces(std::string const& str);
-std::string strip_spaces(std::string const& str);
-bool is_escaped_char(std::string const& str, size_t pos);
+std::string trim_leading_spaces(std::string const& str);
+std::string trim_spaces(std::string const& str);
 /**
  * @brief strip comment, which starts with "//", from a string
  *
  * @param line
  * @return std::string
  */
-inline std::string strip_comments(std::string const& line) { return line.substr(0, line.find("//")); }
+inline std::string trim_comments(std::string const& line) { return line.substr(0, line.find("//")); }
 std::string remove_brackets(std::string const& str, char const left, char const right);
 size_t str_get_token(std::string const& str, std::string& tok, size_t pos = 0, std::string const& delim = " \t\n\v\f\r");
 size_t str_get_token(std::string const& str, std::string& tok, size_t pos, char const delim);
@@ -188,7 +186,7 @@ T detail::stonum(std::string const& str, size_t* pos) {
 
         // unsigned integer types
         if constexpr (std::is_same<T, unsigned>::value) {
-            if (dvlab::str::strip_spaces(str)[0] == '-') throw std::out_of_range("unsigned number underflow");
+            if (dvlab::str::trim_spaces(str)[0] == '-') throw std::out_of_range("unsigned number underflow");
             unsigned long result = std::stoul(str, pos);  // NOTE - for some reason there isn't stou (lol)
             if (result > std::numeric_limits<unsigned>::max()) {
                 throw std::out_of_range("stou");
@@ -196,11 +194,11 @@ T detail::stonum(std::string const& str, size_t* pos) {
             return (unsigned)result;
         }
         if constexpr (std::is_same<T, unsigned long>::value) {
-            if (dvlab::str::strip_spaces(str)[0] == '-') throw std::out_of_range("unsigned number underflow");
+            if (dvlab::str::trim_spaces(str)[0] == '-') throw std::out_of_range("unsigned number underflow");
             return std::stoul(str, pos);
         }
         if constexpr (std::is_same<T, unsigned long long>::value) {
-            if (dvlab::str::strip_spaces(str)[0] == '-') throw std::out_of_range("unsigned number underflow");
+            if (dvlab::str::trim_spaces(str)[0] == '-') throw std::out_of_range("unsigned number underflow");
             return std::stoull(str, pos);
         }
 

--- a/src/zx/simplifier/hadamard_fusion_rule.cpp
+++ b/src/zx/simplifier/hadamard_fusion_rule.cpp
@@ -14,17 +14,10 @@ using MatchType = HadamardFusionRule::MatchType;
 std::vector<MatchType> HadamardFusionRule::find_matches(ZXGraph const& graph) const {
     std::vector<MatchType> matches;
 
-    std::unordered_map<size_t, size_t> id2idx;
-    size_t count = 0;
-    for (auto const& v : graph.get_vertices()) {
-        id2idx[v->get_id()] = count;
-        count++;
-    }
-
     // Matches Hadamard-edges that are connected to H-boxes
     std::unordered_set<ZXVertex*> taken;
 
-    graph.for_each_edge([&graph, &id2idx, &matches, &taken, this](EdgePair const& epair) {
+    graph.for_each_edge([&graph, &matches, &taken](EdgePair const& epair) {
         // NOTE - Only Hadamard Edges
         if (epair.second != EdgeType::hadamard) return;
         auto [neighbor_left, neighbor_right] = epair.first;
@@ -60,7 +53,7 @@ std::vector<MatchType> HadamardFusionRule::find_matches(ZXGraph const& graph) co
         }
     });
 
-    graph.for_each_edge([&id2idx, &taken, &matches, this](EdgePair const& epair) {
+    graph.for_each_edge([&taken, &matches](EdgePair const& epair) {
         if (epair.second == EdgeType::hadamard) return;
 
         auto [neighbor_left, neighbor_right] = epair.first;

--- a/src/zx/simplifier/pivot_boundary_rule.cpp
+++ b/src/zx/simplifier/pivot_boundary_rule.cpp
@@ -15,7 +15,7 @@ std::vector<MatchType> PivotBoundaryRule::find_matches(ZXGraph const& graph) con
     std::vector<MatchType> matches;
 
     std::unordered_set<ZXVertex*> taken;
-    auto match_boundary = [&taken, &graph, &matches, this](ZXVertex* v) {
+    auto match_boundary = [&taken, &graph, &matches](ZXVertex* v) {
         ZXVertex* vs = graph.get_first_neighbor(v).first;
         if (taken.contains(vs)) return;
 

--- a/src/zx/simplifier/pivot_gadget_rule.cpp
+++ b/src/zx/simplifier/pivot_gadget_rule.cpp
@@ -14,11 +14,9 @@ using MatchType = PivotGadgetRule::MatchType;
 std::vector<MatchType> PivotGadgetRule::find_matches(ZXGraph const& graph) const {
     std::vector<MatchType> matches;
 
-    size_t count = 0;
-
     std::unordered_set<ZXVertex*> taken;
 
-    graph.for_each_edge([&graph, &count, &taken, &matches, this](EdgePair const& epair) {
+    graph.for_each_edge([&graph, &taken, &matches](EdgePair const& epair) {
         if (epair.second != EdgeType::hadamard) return;
 
         ZXVertex* vs = epair.first.first;

--- a/src/zx/simplifier/pivot_rule.cpp
+++ b/src/zx/simplifier/pivot_rule.cpp
@@ -20,7 +20,7 @@ std::vector<MatchType> PivotRule::find_matches(ZXGraph const& graph) const {
     std::vector<MatchType> matches;
 
     std::unordered_set<ZXVertex*> taken;
-    graph.for_each_edge([&graph, &taken, &matches, this](EdgePair const& epair) {
+    graph.for_each_edge([&graph, &taken, &matches](EdgePair const& epair) {
         if (epair.second != EdgeType::hadamard) return;
 
         // 2: Get Neighbors

--- a/src/zx/zx_cmd.cpp
+++ b/src/zx/zx_cmd.cpp
@@ -138,7 +138,7 @@ Command zxgraph_mgr_reset_cmd(ZXGraphMgr& zxgraph_mgr) {
                 parser.description("reset ZXGraphMgr");
             },
             [&](ArgumentParser const& /*parser*/) {
-                zxgraph_mgr.reset();
+                zxgraph_mgr.clear();
                 return CmdExecResult::done;
             }};
 }

--- a/src/zx/zx_file_parser.cpp
+++ b/src/zx/zx_file_parser.cpp
@@ -49,7 +49,7 @@ bool ZXFileParser::_parse_internal(std::ifstream& f) {
     // <VertexString> [(<Qubit, Column>)] [NeighborString...] [Phase phase]
     _line_no = 1;
     for (std::string line; getline(f, line); _line_no++) {
-        line = dvlab::str::strip_spaces(dvlab::str::strip_comments(line));
+        line = dvlab::str::trim_spaces(dvlab::str::trim_comments(line));
         if (line.empty()) continue;
 
         std::vector<std::string> tokens;
@@ -123,7 +123,7 @@ bool ZXFileParser::_tokenize(std::string const& line, std::vector<std::string>& 
                 return false;
             }
 
-            token = dvlab::str::strip_spaces(token);
+            token = dvlab::str::trim_spaces(token);
             if (token == "") {
                 _print_failed_at_line_no();
                 std::cerr << "missing argument before comma!!" << std::endl;
@@ -133,7 +133,7 @@ bool ZXFileParser::_tokenize(std::string const& line, std::vector<std::string>& 
 
             dvlab::str::str_get_token(line, token, pos + 1, ')');
 
-            token = dvlab::str::strip_spaces(token);
+            token = dvlab::str::trim_spaces(token);
             if (token == "") {
                 _print_failed_at_line_no();
                 std::cerr << "missing argument before right parenthesis!!" << std::endl;

--- a/src/zx/zx_io.cpp
+++ b/src/zx/zx_io.cpp
@@ -142,7 +142,7 @@ bool ZXGraph::_build_graph_from_parser_storage(detail::StorageType const& storag
     for (auto& [id, info] : storage) {
         ZXVertex* v = std::invoke(
             // clang++ does not support structured binding capture by reference with OpenMP
-            [&id = id, &info = info, this]() {
+            [&info = info, this]() {
                 if (info.type == 'I')
                     return add_input(info.qubit, info.column);
                 if (info.type == 'O')
@@ -222,7 +222,7 @@ bool ZXGraph::write_tikz(std::ostream& os) const {
     auto get_attr_string = [](ZXVertex* v) {
         std::string result = vt2s.at(v->get_type());
         // don't print phase for zero-phase vertices, except for h-boxes we don't print when phase is pi.
-        if ((v->get_phase() == Phase(0) && !v->is_hbox() || v->get_phase() == Phase(1) && v->is_hbox())) {
+        if ((v->get_phase() == Phase(0) && !v->is_hbox()) || (v->get_phase() == Phase(1) && v->is_hbox())) {
             return result;
         }
 

--- a/src/zx/zx_partition.cpp
+++ b/src/zx/zx_partition.cpp
@@ -289,7 +289,6 @@ std::pair<ZXVertexList, ZXVertexList> detail::kl_bipartition(ZXGraph const& grap
         }
     };
 
-    size_t iteration = 0;
     while (!stop_requested()) {
         cumulative_gain      = 0;
         swap_history         = std::stack<SwapPair>();

--- a/src/zx/zx_traverse.cpp
+++ b/src/zx/zx_traverse.cpp
@@ -22,7 +22,6 @@ namespace qsyn::zx {
  */
 std::vector<ZXVertex*> ZXGraph::create_topological_order() const {
     std::vector<ZXVertex*> topological_order;
-    size_t global_traversal_counter = 0;
     std::unordered_set<ZXVertex*> dfs_counters;
     for (auto const& v : _inputs) {
         if (!dfs_counters.contains(v))

--- a/src/zx/zxgraph_print.cpp
+++ b/src/zx/zxgraph_print.cpp
@@ -8,6 +8,7 @@
 #include <spdlog/spdlog.h>
 
 #include <cstddef>
+#include <gsl/narrow>
 #include <map>
 #include <ranges>
 #include <string>
@@ -222,7 +223,9 @@ void ZXGraph::draw() const {
     }
     qubit_ids_temp.clear();
 
-    for (QubitIdType i = 0; i < qubit_ids.size(); i++) q_pair[i] = qubit_ids[i];
+    for (size_t i = 0; i < qubit_ids.size(); i++) {
+        q_pair[gsl::narrow<QubitIdType>(i)] = qubit_ids[gsl::narrow<QubitIdType>(i)];
+    }
     std::vector<ZXVertex*> tmp;
     tmp.resize(qubit_ids.size());
     std::vector<std::vector<ZXVertex*>> col_list(max_col + 1, tmp);
@@ -256,7 +259,7 @@ void ZXGraph::draw() const {
 
         // print row
         for (size_t j = 0; j <= max_col; j++) {
-            if (i < -offset) {
+            if (std::cmp_less(i, -offset)) {
                 if (col_list[j][i] != nullptr) {
                     std::cout << "(" << detail::get_colored_vertex_string(col_list[j][i]) << ")   ";
                 } else {

--- a/tests/cli/dof/alias.dof
+++ b/tests/cli/dof/alias.dof
@@ -1,10 +1,10 @@
-qq -h
-alias qqqq qccr
-qq -h
-qqq -h
-qqu -h
-alias -d qqqq
-qquit -h
-qqq -h
-qq -h
-qq -f
+exi -h
+alias exir qccr
+exi -h
+exir -h
+exit -h
+alias -d exir
+exit -h
+exir -h
+exi -h
+exit -f

--- a/tests/cli/dof/dofile.dof
+++ b/tests/cli/dof/dofile.dof
@@ -12,10 +12,10 @@ help $1 // should print help message of dofile command
 dofile tests/cli/helper/param_dof_kw // should error and print usage
 dofile tests/cli/helper/param_dof_kw haha1 haha2 haha3 // should error and print usage
 
-dofile tests/cli/helper/param_dof_kw qquit dofile
-help ${input1} // print help message of qquit
+dofile tests/cli/helper/param_dof_kw exit dofile
+help ${input1} // print help message of exit
 help $input2   // print help message of dofile
-help $1        // print help message of qquit
+help $1        // print help message of exit
 help ${2}      // print help message of dofile
 
 qq -f

--- a/tests/cli/dof/variable_substitution.dof
+++ b/tests/cli/dof/variable_substitution.dof
@@ -1,0 +1,13 @@
+set var1 bench
+set var2 mark
+qccr $var1$var2/SABRE/small/3_17_13.qasm
+qcp -l
+qccr ${var1}$var2/SABRE/small/3_17_13.qasm
+qcp -l
+qccr $var1${var2}/SABRE/small/3_17_13.qasm
+qcp -l
+qccr ${var1}${var2}/SABRE/small/3_17_13.qasm
+qcp -l
+
+qcp -l
+q -f

--- a/tests/cli/ref/alias.log
+++ b/tests/cli/ref/alias.log
@@ -1,5 +1,5 @@
-qsyn> qq -h
-Usage: qquit [-h] [-force]
+qsyn> exi -h
+Usage: exit [-h] [-force]
 
 Description:
   quit Qsyn
@@ -8,12 +8,12 @@ Options:
   flag  -h, --help    show this help message and exit 
   flag  -force        quit without reaffirming        
 
-qsyn> alias qqqq qccr
+qsyn> alias exir qccr
 
-qsyn> qq -h
-[error]    Ambiguous command or alias `qq`!!
+qsyn> exi -h
+[error]    Ambiguous command or alias `exi`!!
 
-qsyn> qqq -h
+qsyn> exir -h
 Usage: qccread [-h] [-replace] <string filepath>
 
 Description:
@@ -26,8 +26,8 @@ Options:
   flag  -h, --help    show this help message and exit                                         
   flag  -replace      if specified, replace the current circuit; otherwise store to a new one 
 
-qsyn> qqu -h
-Usage: qquit [-h] [-force]
+qsyn> exit -h
+Usage: exit [-h] [-force]
 
 Description:
   quit Qsyn
@@ -36,23 +36,10 @@ Options:
   flag  -h, --help    show this help message and exit 
   flag  -force        quit without reaffirming        
 
-qsyn> alias -d qqqq
+qsyn> alias -d exir
 
-qsyn> qquit -h
-Usage: qquit [-h] [-force]
-
-Description:
-  quit Qsyn
-
-Options:
-  flag  -h, --help    show this help message and exit 
-  flag  -force        quit without reaffirming        
-
-qsyn> qqq -h
-[error]    Unknown command or alias `qqq`!!
-
-qsyn> qq -h
-Usage: qquit [-h] [-force]
+qsyn> exit -h
+Usage: exit [-h] [-force]
 
 Description:
   quit Qsyn
@@ -61,5 +48,18 @@ Options:
   flag  -h, --help    show this help message and exit 
   flag  -force        quit without reaffirming        
 
-qsyn> qq -f
+qsyn> exir -h
+[error]    Unknown command!! (exir)
+
+qsyn> exi -h
+Usage: exit [-h] [-force]
+
+Description:
+  quit Qsyn
+
+Options:
+  flag  -h, --help    show this help message and exit 
+  flag  -force        quit without reaffirming        
+
+qsyn> exit -f
 

--- a/tests/cli/ref/dofile.log
+++ b/tests/cli/ref/dofile.log
@@ -12,16 +12,12 @@ qsyn> // placeholder
 qsyn> help $1 // should print all help messages
 alias          : alias a command to another name
 clear          : clear the terminal
+device         : device commands
 dofile         : execute the commands in the dofile
-dtcheckout     : checkout to Device <id> in DeviceMgr
-dtdelete       : remove a Device from DeviceMgr
-dtgprint       : print info of device topology
-dtgread        : read a device topology
-dtprint        : print info about Devices
-dtreset        : reset DeviceMgr
 duoprint       : print Duostra parameters
 duoset         : set Duostra parameter(s)
 duostra        : map logical circuit to physical circuit
+exit           : quit Qsyn
 extprint       : print info of extracting ZXGraph
 extract        : perform step(s) in extraction
 extset         : set extractor parameters
@@ -50,8 +46,8 @@ qcprint        : print info about QCirs or settings
 qcreset        : reset QCirMgr
 qcset          : set QCir parameters
 qctensor       : tensor a QCir
-qquit          : quit Qsyn
 seed           : set the random seed
+set            : set a variable
 tsadjoint      : adjoint the specified tensor
 tsequiv        : check the equivalency of two stored tensors
 tsprint        : print info about Tensors
@@ -106,11 +102,11 @@ qsyn> dofile tests/cli/helper/param_dof_kw haha1 haha2 haha3 // should error and
 [error]    Usage: ... tests/cli/helper/param_dof_kw <input1> <input2>
 
 qsyn> 
-qsyn> dofile tests/cli/helper/param_dof_kw qquit dofile
+qsyn> dofile tests/cli/helper/param_dof_kw exit dofile
 
 qsyn> //!ARGS input1 input2
-qsyn> help ${input1} // print help message of qquit
-Usage: qquit [-h] [-force]
+qsyn> help ${input1} // print help message of exit
+Usage: exit [-h] [-force]
 
 Description:
   quit Qsyn
@@ -132,8 +128,8 @@ Positional Arguments:
 Options:
   flag  -h, --help    show this help message and exit 
 
-qsyn> help $1        // print help message of qquit
-Usage: qquit [-h] [-force]
+qsyn> help $1        // print help message of exit
+Usage: exit [-h] [-force]
 
 Description:
   quit Qsyn

--- a/tests/cli/ref/logger.log
+++ b/tests/cli/ref/logger.log
@@ -11,7 +11,7 @@ qsyn> logger test
 Regular printing (level `off`)
 [critical] A log message with level `critical`
 [error]    A log message with level `error`
-[warn]     A log message with level `warn`
+[warn]     A log message with level `warning`
 [info]     A log message with level `info`
 [debug]    A log message with level `debug`
 

--- a/tests/cli/ref/variable_substitution.log
+++ b/tests/cli/ref/variable_substitution.log
@@ -1,0 +1,39 @@
+qsyn> set var1 bench
+
+qsyn> set var2 mark
+
+qsyn> qccr $var1$var2/SABRE/small/3_17_13.qasm
+
+qsyn> qcp -l
+★ 0    3_17_13             
+
+qsyn> qccr ${var1}$var2/SABRE/small/3_17_13.qasm
+
+qsyn> qcp -l
+  0    3_17_13             
+★ 1    3_17_13             
+
+qsyn> qccr $var1${var2}/SABRE/small/3_17_13.qasm
+
+qsyn> qcp -l
+  0    3_17_13             
+  1    3_17_13             
+★ 2    3_17_13             
+
+qsyn> qccr ${var1}${var2}/SABRE/small/3_17_13.qasm
+
+qsyn> qcp -l
+  0    3_17_13             
+  1    3_17_13             
+  2    3_17_13             
+★ 3    3_17_13             
+
+qsyn> 
+qsyn> qcp -l
+  0    3_17_13             
+  1    3_17_13             
+  2    3_17_13             
+★ 3    3_17_13             
+
+qsyn> q -f
+

--- a/tests/conversion/duostra/dof/cm82a_208.dof
+++ b/tests/conversion/duostra/dof/cm82a_208.dof
@@ -2,7 +2,7 @@ qcp -se
 qcset -double 2 -sw 6
 qcp -se
 qccr benchmark/SABRE/large/cm82a_208.qasm
-dtgr benchmark/topology/guadalupe.layout 
+device read benchmark/topology/guadalupe.layout 
 qccp -a
 duoprint -d
 duoset -depth 2 -si true

--- a/tests/conversion/duostra/dof/mpeqv.dof
+++ b/tests/conversion/duostra/dof/mpeqv.dof
@@ -1,4 +1,4 @@
-dtgr benchmark/topology/guadalupe.layout
+device read benchmark/topology/guadalupe.layout
 qcset -d 2 -sw 6
 qccr benchmark/SABRE/small/3_17_13.qasm
 duostra -c

--- a/tests/conversion/duostra/ref/cm82a_208.log
+++ b/tests/conversion/duostra/ref/cm82a_208.log
@@ -16,7 +16,7 @@ Delay of Multiple-qubit gate :   5
 
 qsyn> qccr benchmark/SABRE/large/cm82a_208.qasm
 
-qsyn> dtgr benchmark/topology/guadalupe.layout 
+qsyn> device read benchmark/topology/guadalupe.layout 
 
 qsyn> qccp -a
 Clifford    : 370

--- a/tests/conversion/duostra/ref/mpeqv.log
+++ b/tests/conversion/duostra/ref/mpeqv.log
@@ -1,4 +1,4 @@
-qsyn> dtgr benchmark/topology/guadalupe.layout
+qsyn> device read benchmark/topology/guadalupe.layout
 
 qsyn> qcset -d 2 -sw 6
 

--- a/tests/conversion/qc2ts/ref/qc2ts.log
+++ b/tests/conversion/qc2ts/ref/qc2ts.log
@@ -48,11 +48,8 @@ qsyn> qc2ts
 [info]     Note: Replacing Tensor 0...
 
 qsyn> logger level warning
-Error: invalid choice "warning": please choose from {off, critical, error, warn, info, debug, trace}!!
-
 
 qsyn> qccr benchmark/qasm/qc2ts/control_h.qasm -r
-[info]     Note: Replacing QCir 0...
 
 qsyn> logger level trace
 [info]     Setting logger level to "trace"
@@ -118,11 +115,8 @@ qsyn> qc2ts
 [info]     Note: Replacing Tensor 1...
 
 qsyn> logger level warning
-Error: invalid choice "warning": please choose from {off, critical, error, warn, info, debug, trace}!!
-
 
 qsyn> qccr benchmark/qasm/qc2ts/toffoli_dec.qasm -r
-[info]     Note: Replacing QCir 0...
 
 qsyn> logger level trace
 [info]     Setting logger level to "trace"
@@ -212,11 +206,8 @@ qsyn> qc2ts
 [info]     Note: Replacing Tensor 2...
 
 qsyn> logger level warning
-Error: invalid choice "warning": please choose from {off, critical, error, warn, info, debug, trace}!!
-
 
 qsyn> qccr benchmark/qasm/qc2ts/toffoli_qiskit.qasm -r
-[info]     Note: Replacing QCir 0...
 
 qsyn> logger level trace
 [info]     Setting logger level to "trace"
@@ -406,11 +397,8 @@ qsyn> qc2ts
 [info]     Note: Replacing Tensor 3...
 
 qsyn> logger level warning
-Error: invalid choice "warning": please choose from {off, critical, error, warn, info, debug, trace}!!
-
 
 qsyn> qccr benchmark/SABRE/small/3_17_13.qasm
-[info]     Successfully created and checked out to QCir 1
 
 qsyn> qccp -q
 Q 0  -----------------cx( 1)-- h( 3)-- t( 6)----------------------------------cx( 8)----------cx( 9)-- t(14)--------------------------cx(15)----------cx(16)-- h(18)-- t(20)------------------cx(23)--------------------------cx(25)----------cx(27)--td(28)--------------------------cx(32)----------cx(33)-
@@ -610,8 +598,6 @@ qsyn> qc2ts
 [info]     Note: Replacing Tensor 4...
 
 qsyn> logger level warning
-Error: invalid choice "warning": please choose from {off, critical, error, warn, info, debug, trace}!!
-
 
 qsyn> qq -f
 

--- a/tests/qcir/pi_reading/ref/pi_input.log
+++ b/tests/qcir/pi_reading/ref/pi_input.log
@@ -3,8 +3,8 @@ Note: QCir list is empty now. Create a new one.
 
 qsyn> qcga rz -ph 11*pi/17 0 
 
-qsyn> qcga rz -ph 1l*pi/17 0 
-Error: invalid Phase value "1l*pi/17" for argument "-phase"!!
+qsyn> Error: invalid Phase value "1l*pi/17" for argument "-phase"!!
+qcga rz -ph 1l*pi/17 0 
 
 qsyn> qcga rz -ph 3*3*PI/4/3 0
 
@@ -12,8 +12,8 @@ qsyn> qcga rz -ph 3*4/PI 0
 
 qsyn> qcga rz -ph PI*PI/pi 0
 
-qsyn> qcga rz -ph PI*3PI/pi 0
-Error: invalid Phase value "PI*3PI/pi" for argument "-phase"!!
+qsyn> Error: invalid Phase value "PI*3PI/pi" for argument "-phase"!!
+qcga rz -ph PI*3PI/pi 0
 
 qsyn> qc2zx
 

--- a/tests/topology/reader/dof/topo_hybrid.dof
+++ b/tests/topology/reader/dof/topo_hybrid.dof
@@ -1,18 +1,18 @@
-dtgr benchmark/topology/ithaca.layout
-dtgp
-dtgr benchmark/topology/example.layout
-dtgp
-dtch 0
-dtp
-dtgp -q
-dtgp -q 15
-dtgp -e 15
-dtp
-dtp -l
-dtgp -p 0 64
-dtgp -p 12 56
-dtgp -p 35 21
-dtgp -p 33 33
+device read benchmark/topology/ithaca.layout
+device print
+device read benchmark/topology/example.layout
+device print
+device checkout 0
+device
+device print -q
+device print -q 15
+device print -e 15
+device
+device list
+device print -p 0 64
+device print -p 12 56
+device print -p 35 21
+device print -p 33 33
 qq -f
 
 

--- a/tests/topology/reader/ref/topo_hybrid.log
+++ b/tests/topology/reader/ref/topo_hybrid.log
@@ -1,22 +1,22 @@
-qsyn> dtgr benchmark/topology/ithaca.layout
+qsyn> device read benchmark/topology/ithaca.layout
 
-qsyn> dtgp
+qsyn> device print
 Topology: ibm_ithaca (65 qubits, 72 edges)
 Gate Set: CX, ID, RZ, SX, X
 
-qsyn> dtgr benchmark/topology/example.layout
+qsyn> device read benchmark/topology/example.layout
 
-qsyn> dtgp
+qsyn> device print
 Topology: example_topology (3 qubits, 2 edges)
 Gate Set: X, RZ, H, ID, SX, CX
 
-qsyn> dtch 0
+qsyn> device checkout 0
 
-qsyn> dtp
+qsyn> device
 -> #Device: 2
 -> Now focused on: Device 0 (ibm_ithaca)
 
-qsyn> dtgp -q
+qsyn> device print -q
 
 ID:   0    Delay:    4.37    Error:  0.0003    Adjs:   1  10
 ID:   1    Delay:    5.94    Error: 0.00016    Adjs:   0   2
@@ -85,40 +85,40 @@ ID:  63    Delay:    4.83    Error: 0.00027    Adjs:  62  64
 ID:  64    Delay:    4.83    Error: 0.00018    Adjs:  54  63
 Total #Qubits: 65
 
-qsyn> dtgp -q 15
+qsyn> device print -q 15
 
 ID:  15    Delay:    5.27    Error: 0.00023    Adjs:  14  16  24
 
-qsyn> dtgp -e 15
+qsyn> device print -e 15
 
 ( 15,  14)    Delay:  561.778    Error:  0.01016
 ( 15,  16)    Delay:  512.000    Error:  0.00690
 ( 15,  24)    Delay:  561.778    Error:  1.00000
 Total #Edges: 3
 
-qsyn> dtp
+qsyn> device
 -> #Device: 2
 -> Now focused on: Device 0 (ibm_ithaca)
 
-qsyn> dtp -l
+qsyn> device list
 ★ 0    ibm_ithaca          #Q:   65
   1    example_topology    #Q:    3
 
-qsyn> dtgp -p 0 64
+qsyn> device print -p 0 64
 
 Path from 0 to 64:
    0    1    2    3    4   11   17   18   19   25 
   33   34   35   40   49   50   51   54   64 
-qsyn> dtgp -p 12 56
+qsyn> device print -p 12 56
 
 Path from 12 to 56:
   12   21   20   19   25   33   32   31   39   45 
   44   43   52   56 
-qsyn> dtgp -p 35 21
+qsyn> device print -p 35 21
 
 Path from 35 to 21:
   35   34   33   25   19   20   21 
-qsyn> dtgp -p 33 33
+qsyn> device print -p 33 33
 
 Path from 33 to 33:
   33 

--- a/tests/zx/graph/ref/print.log
+++ b/tests/zx/graph/ref/print.log
@@ -6,8 +6,8 @@ ID:   1 (●, 0)           (Qubit, Col): (1, 0)         #Neighbors:   1     (3, 
 ID:   0 (●, 0)           (Qubit, Col): (0, 0)         #Neighbors:   1     (2, -)
 
 
-qsyn> zxgp -v 1 0 d 9
-Error: invalid size_t value "d" for argument "-vertices"!!
+qsyn> Error: invalid size_t value "d" for argument "-vertices"!!
+zxgp -v 1 0 d 9
 
 qsyn> zxgp -q 1 2
 


### PR DESCRIPTION
## Check List
1. [x] Does your submission pass tests by running `./RUN_TEST`?
2. [x] Have you linted your code locally with `./scripts/LINT` before submission?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!-- Link to specific issues where it seems fit. -->

### Added
- Alias system for commands
- Tab completion supports for aliases

### Changed
- The logic of parsing user input with quotes. Now, the single quotes escape any special character, while double quotes keep `$` and `\` as escape characters so that variable substitution still works in them.
- Device commands reconstructed as a series of subcommands (command restructure part 1/?)
-  Allowed aliases to shadow existing commands
-  Allowed aliases to be overwritten without having to call `alias -d` first

### Fixed
- Variable substitution errors when replacing two or more variables in one line of user input
- Tab completion sometimes does not act correctly for escaped characters in the input
- Printing help messages causing segfaults if the terminal is too narrow

### Removed
- The API of `dvlab::argparse::ArgumentParser` to pass in a string and parse before tokenization. This functionality is moved to the calling side. In this case, `dvlab::CommandLineInterface`.