### PR TITLE
:recycle: range-based tokenization helper functions, number parsing functions that returns an optional

### DIFF
--- a/src/argparse/arg_def.hpp
+++ b/src/argparse/arg_def.hpp
@@ -36,7 +36,14 @@ concept valid_argument_type = requires(T t) {
 
 template <typename T>
 requires std::is_arithmetic_v<T>
-bool parse_from_string(T& val, std::string const& token) { return dvlab::str::str_to_num<T>(token, val); }
+bool parse_from_string(T& val, std::string const& token) {
+    auto result = dvlab::str::from_string<T>(token);
+    if (result.has_value()) {
+        val = result.value();
+        return true;
+    }
+    return false;
+}
 
 // NOTE - keep in the header to shadow the previous definition (bool is arithmetic type)
 template <>

--- a/src/argparse/arg_parser_print.cpp
+++ b/src/argparse/arg_parser_print.cpp
@@ -13,6 +13,7 @@
 #include <numeric>
 #include <ranges>
 #include <tl/enumerate.hpp>
+#include <tl/to.hpp>
 
 #include "./argparse.hpp"
 #include "unicode/display_width.hpp"
@@ -148,8 +149,7 @@ std::string get_syntax(ArgumentParser parser, MutuallyExclusiveGroup const& grou
  */
 std::string wrap_text(std::string const& str, size_t max_help_width) {
     if (!dvlab::utils::is_terminal()) return str;
-
-    std::vector<std::string> lines = dvlab::str::split(str, "\n");
+    auto lines = dvlab::str::views::split_to_string_views(str, '\n') | tl::to<std::vector>();
 
     // NOTE - the following code modifies the vector while iterating over it.
     //        don't use range-based for loop here.

--- a/src/cli/cli_exec.cpp
+++ b/src/cli/cli_exec.cpp
@@ -135,7 +135,8 @@ dvlab::CommandLineInterface::_parse_one_command(std::string_view cmd) {
     buffer = _replace_variable_keys_with_values(buffer);
 
     // get the first token again (since the first token may be a variable)
-    first_space_pos = dvlab::str::str_get_token(buffer, first_token);
+    first_space_pos = _get_first_token_pos(buffer);
+    first_token     = buffer.substr(0, first_space_pos);
 
     dvlab::Command* command = get_command(first_token);
 

--- a/src/cli/cli_listen.cpp
+++ b/src/cli/cli_listen.cpp
@@ -156,17 +156,17 @@ std::pair<CmdExecResult, std::string> dvlab::CommandLineInterface::listen_to_inp
         auto keycode = get_char(istr);
 
         if (istr.eof()) {
-            return {CmdExecResult::done, dvlab::str::trim_spaces(dvlab::str::trim_comments(_read_buffer))};
+            return {CmdExecResult::done, std::string{dvlab::str::trim_spaces(dvlab::str::trim_comments(_read_buffer))}};
         }
 
         if (keycode == input_end_key) {
-            return {CmdExecResult::quit, dvlab::str::trim_spaces(dvlab::str::trim_comments(_read_buffer))};
+            return {CmdExecResult::quit, std::string{dvlab::str::trim_spaces(dvlab::str::trim_comments(_read_buffer))}};
         }
 
         switch (keycode) {
             case newline_key: {
                 if (_dequote(_read_buffer).has_value()) {
-                    return {CmdExecResult::done, dvlab::str::trim_spaces(dvlab::str::trim_comments(_read_buffer))};
+                    return {CmdExecResult::done, std::string{dvlab::str::trim_spaces(dvlab::str::trim_comments(_read_buffer))}};
                 } else {
                     fmt::print("\n{0:<{1}}", "...", _command_prompt.size());
                     break;

--- a/src/qcir/optimizer/basic_optimization.cpp
+++ b/src/qcir/optimizer/basic_optimization.cpp
@@ -16,6 +16,7 @@
 #include "../qcir_gate.hpp"
 #include "./optimizer.hpp"
 #include "fmt/core.h"
+#include "util/dvlab_string.hpp"
 #include "util/phase.hpp"
 #include "util/util.hpp"
 
@@ -148,7 +149,7 @@ QCir Optimizer::_parse_once(QCir const& qcir, bool reversed, bool do_minimize_cz
     if (config.printStatistics) {
         fmt::println("{}", statistics_str);
     }
-    for (auto& line : dvlab::str::split(statistics_str, "\n")) {
+    for (auto const& line : dvlab::str::views::split_to_string_views(statistics_str, "\n")) {
         spdlog::debug("{}", line);
     }
     spdlog::debug("");

--- a/src/util/dvlab_string.cpp
+++ b/src/util/dvlab_string.cpp
@@ -60,7 +60,7 @@ std::string remove_brackets(std::string const& str, char const left, char const 
 // (i.e. "delim" or string::npos) if found.
 // This function will not treat '\ ' as a space in the token. That is, "a\ b" is two token ("a\", "b") and not one
 size_t
-str_get_token(std::string const& str, std::string& tok, size_t pos, std::string const& delim) {
+str_get_token(std::string_view str, std::string& tok, size_t pos, std::string const& delim) {
     auto const begin = str.find_first_not_of(delim, pos);
     if (begin == std::string::npos) {
         tok = "";
@@ -71,7 +71,7 @@ str_get_token(std::string const& str, std::string& tok, size_t pos, std::string 
     return end;
 }
 
-size_t str_get_token(std::string const& str, std::string& tok, size_t pos, char const delim) {
+size_t str_get_token(std::string_view str, std::string& tok, size_t pos, char const delim) {
     return str_get_token(str, tok, pos, std::string(1, delim));
 }
 
@@ -101,8 +101,8 @@ char toupper(char ch) {
  * @param str
  * @return std::string
  */
-std::string tolower_string(std::string const& str) {
-    std::string ret = str;
+std::string tolower_string(std::string_view str) {
+    std::string ret{str};
     std::for_each(ret.begin(), ret.end(), [](char& ch) { ch = dvlab::str::tolower(ch); });
     return ret;
 };
@@ -113,33 +113,11 @@ std::string tolower_string(std::string const& str) {
  * @param str
  * @return std::string
  */
-std::string toupper_string(std::string const& str) {
-    std::string ret = str;
+std::string toupper_string(std::string_view str) {
+    std::string ret{str};
     std::for_each(ret.begin(), ret.end(), [](char& ch) { ch = dvlab::str::toupper(ch); });
     return ret;
 };
-
-std::vector<std::string> split(std::string const& str, std::string const& delim = " ") {
-    std::vector<std::string> result;
-    std::string token;
-    size_t pos = str_get_token(str, token, 0, delim);
-    while (token.size()) {
-        result.emplace_back(token);
-        pos = str_get_token(str, token, pos, delim);
-    }
-
-    return result;
-}
-
-std::string join(std::string const& infix, std::span<std::string> strings) {
-    std::string result = *strings.begin();
-
-    for (auto& str : strings.subspan(1)) {
-        result += infix + str;
-    }
-
-    return result;
-}
 
 //---------------------------------------------
 // number parsing

--- a/src/util/phase.hpp
+++ b/src/util/phase.hpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <iosfwd>
 #include <numbers>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -87,13 +88,13 @@ public:
 
     template <class T = double>
     requires std::floating_point<T>
-    static bool
-    from_string(std::string const& str, Phase& phase) {
+    static std::optional<Phase>
+    from_string(std::string const& str) {
+        Phase phase;
         if (!str_to_phase<T>(str, phase)) {
-            phase = Phase(0);
-            return false;
+            return std::nullopt;
         }
-        return true;
+        return phase;
     }
 
     template <class T = double>

--- a/src/zx/zx_file_parser.hpp
+++ b/src/zx/zx_file_parser.hpp
@@ -39,7 +39,7 @@ private:
     // parsing subroutines
     bool _tokenize(std::string const& line, std::vector<std::string>& tokens);
 
-    bool _parse_type_and_id(std::string const& token, char& type, unsigned& id);
+    std::optional<std::pair<char, unsigned>> _parse_type_and_id(std::string const& token);
     bool _is_valid_tokens_for_boundary_vertex(std::vector<std::string> const& tokens);
     bool _is_valid_tokens_for_h_box(std::vector<std::string> const& tokens);
 

--- a/tests/qcir/optimizer/ref/optimize.log
+++ b/tests/qcir/optimizer/ref/optimize.log
@@ -37,6 +37,7 @@ qsyn> qccoptimize
 [debug]            0 CXs had been transformed into CZs.
 [debug]      Note: 0 swap gates had been added in the swap path.
 [debug]    
+[debug]    
 [debug]    Start parsing backward
 [trace]    Transform X gate into Z gate
 [trace]    Apply a do_swap commutation
@@ -57,6 +58,7 @@ qsyn> qccoptimize
 [debug]      Note: 0 CZs had been transformed into CXs.
 [debug]            105 CXs had been transformed into CZs.
 [debug]      Note: 4 swap gates had been added in the swap path.
+[debug]    
 [debug]    
 [debug]    Start parsing forward
 [trace]    Apply a do_swap commutation
@@ -85,6 +87,7 @@ qsyn> qccoptimize
 [debug]            0 CXs had been transformed into CZs.
 [debug]      Note: 3 swap gates had been added in the swap path.
 [debug]    
+[debug]    
 [debug]    Start parsing backward
 [trace]    Apply a do_swap commutation
 [trace]    Cancel with previous CX
@@ -105,6 +108,7 @@ qsyn> qccoptimize
 [debug]      Note: 0 CZs had been transformed into CXs.
 [debug]            52 CXs had been transformed into CZs.
 [debug]      Note: 3 swap gates had been added in the swap path.
+[debug]    
 [debug]    
 [debug]    Start parsing forward
 [trace]    Apply a do_swap commutation
@@ -131,6 +135,7 @@ qsyn> qccoptimize
 [debug]            0 CXs had been transformed into CZs.
 [debug]      Note: 2 swap gates had been added in the swap path.
 [debug]    
+[debug]    
 [debug]    Start parsing backward
 [trace]    Apply a do_swap commutation
 [trace]    Cancel with previous CX
@@ -149,6 +154,7 @@ qsyn> qccoptimize
 [debug]      Note: 0 CZs had been transformed into CXs.
 [debug]            53 CXs had been transformed into CZs.
 [debug]      Note: 2 swap gates had been added in the swap path.
+[debug]    
 [debug]    
 [debug]    Start parsing forward
 [trace]    Apply a do_swap commutation
@@ -172,6 +178,7 @@ qsyn> qccoptimize
 [debug]            0 CXs had been transformed into CZs.
 [debug]      Note: 2 swap gates had been added in the swap path.
 [debug]    
+[debug]    
 [debug]    Start parsing backward
 [trace]    Apply a do_swap commutation
 [trace]    Cancel with previous CX
@@ -190,6 +197,7 @@ qsyn> qccoptimize
 [debug]      Note: 0 CZs had been transformed into CXs.
 [debug]            35 CXs had been transformed into CZs.
 [debug]      Note: 2 swap gates had been added in the swap path.
+[debug]    
 [debug]    
 [debug]    Start parsing forward
 [trace]    Apply a do_swap commutation
@@ -212,6 +220,7 @@ qsyn> qccoptimize
 [debug]      Note: 35 CZs had been transformed into CXs.
 [debug]            0 CXs had been transformed into CZs.
 [debug]      Note: 2 swap gates had been added in the swap path.
+[debug]    
 [debug]    
 [info]     Basic optimization finished after 19 iterations.
 [info]       Two-qubit gates: 1498 → 1498


### PR DESCRIPTION
## Check List
1. [x] Does your submission pass tests by running `./RUN_TEST`?
2. [x] Have you linted your code locally with `./scripts/LINT` before submission?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!-- Link to specific issues where seems fit. -->

### Added
- Some tokenization helpers in the namespace `dvlab::str::views`
    - `split_to_string_views` is a wrapper that performs `std::views::split` to a string and converts the resulting ranges to `string_view`s
    - `skip_empty` skips empty `string_view`s
    - `trim_spaces` trims the leading and trailing spaces in the `string_view`s
    - `tokenize` combines the above three operations.
- Some parsing helpers in the namespace `dvlab::str`
    - `from_string<T>` wraps the `from_chars<T>` introduced in c++17 and returns a `std::optional<T>`.

If the above two additions prove themselves to be superior to the existing solutions, then maybe we can deprecate the existing ones (`str_to_*` functions, `str_get_token`)

### Changed
- `Phase::from_string<T>` now returns a `std::optional<Phase>` as a step to unify the calling interfaces of these parsing utils.

### Fixed
- CLI not getting the correct `first_token` to search the command name after expanding an alias

### Removed
- `dvlab::str::{join|split}`