### PR TITLE
:sparkles: Multiple single-character arguments can now be collapsed

### DIFF
--- a/src/argparse/arg_def.hpp
+++ b/src/argparse/arg_def.hpp
@@ -30,7 +30,7 @@ struct Token {
     bool parsed;
 };
 
-using TokensView = std::span<Token>;
+using TokensSpan = std::span<Token>;
 
 template <typename T>
 std::string type_string(T const&);

--- a/src/argparse/arg_parser.cpp
+++ b/src/argparse/arg_parser.cpp
@@ -369,11 +369,9 @@ bool ArgumentParser::_parse_options(TokensSpan tokens) {
             if (dvlab::str::from_string<float>(token).has_value()) {
                 continue;
             }
-            auto frequency = std::get<size_t>(match);
-            assert(frequency != 1);
 
             // If the option is ambiguous, report the error and quit parsing
-            if (frequency > 0) {
+            if (*p_frequency > 0) {
                 auto const matching_option_filter = [this, &token = token](std::string const& name) {
                     return has_option_prefix(name) && name.starts_with(token);
                 };
@@ -428,7 +426,7 @@ std::pair<std::vector<std::string>, std::string> ArgumentParser::_explode_option
             }
         }
         // if we encounter a single-char that does not match any option, then everything after it is the argument for the last option
-        else if (auto p_frequency = std::get_if<size_t>(&match)) {
+        else if (std::get_if<size_t>(&match)) {
             remainder_token = token.substr(j + 2);
         }
     }

--- a/src/argparse/arg_parser.cpp
+++ b/src/argparse/arg_parser.cpp
@@ -14,6 +14,7 @@
 #include <ranges>
 #include <stdexcept>
 
+#include "argparse/arg_def.hpp"
 #include "fmt/core.h"
 #include "tl/adjacent.hpp"
 #include "tl/enumerate.hpp"
@@ -240,7 +241,7 @@ bool ArgumentParser::parse_args(std::vector<std::string> const& tokens) {
  * @return true
  * @return false
  */
-bool ArgumentParser::parse_args(TokensView tokens) {
+bool ArgumentParser::parse_args(TokensSpan tokens) {
     auto [success, unrecognized] = parse_known_args(tokens);
 
     if (!success) return false;
@@ -269,7 +270,7 @@ std::pair<bool, std::vector<Token>> ArgumentParser::parse_known_args(std::vector
  *         the first return value specifies whether the parse has succeeded, and
  *         the second one specifies the unrecognized tokens
  */
-std::pair<bool, std::vector<Token>> ArgumentParser::parse_known_args(TokensView tokens) {
+std::pair<bool, std::vector<Token>> ArgumentParser::parse_known_args(TokensSpan tokens) {
     auto result = _parse_known_args_impl(tokens);
     if (!result.first && _pimpl->config.exit_on_failure) {
         exit(0);
@@ -284,7 +285,7 @@ std::pair<bool, std::vector<Token>> ArgumentParser::parse_known_args(TokensView 
  * @param tokens
  * @return std::pair<bool, std::vector<Token>>
  */
-std::pair<bool, std::vector<Token>> ArgumentParser::_parse_known_args_impl(TokensView tokens) {
+std::pair<bool, std::vector<Token>> ArgumentParser::_parse_known_args_impl(TokensSpan tokens) {
     if (!analyze_options()) return {false, {}};
     _pimpl->activated_subparser = std::nullopt;
     for (auto& mutex : _pimpl->mutually_exclusive_groups) {
@@ -309,7 +310,7 @@ std::pair<bool, std::vector<Token>> ArgumentParser::_parse_known_args_impl(Token
         arg.reset();
     }
 
-    TokensView const main_parser_tokens = tokens.subspan(0, subparser_token_pos);
+    TokensSpan const main_parser_tokens = tokens.subspan(0, subparser_token_pos);
 
     std::vector<Token> unrecognized;
     if (!_parse_options(main_parser_tokens) ||
@@ -318,7 +319,7 @@ std::pair<bool, std::vector<Token>> ArgumentParser::_parse_known_args_impl(Token
     }
     _fill_unparsed_args_with_defaults();
     if (has_subparsers()) {
-        TokensView const subparser_tokens = tokens.subspan(subparser_token_pos + 1);
+        TokensSpan const subparser_tokens = tokens.subspan(subparser_token_pos + 1);
         if (_pimpl->activated_subparser) {
             auto const [success, subparser_unrecognized] = get_activated_subparser()->parse_known_args(subparser_tokens);
             if (!success) return {false, {}};
@@ -338,62 +339,128 @@ std::pair<bool, std::vector<Token>> ArgumentParser::_parse_known_args_impl(Token
  * @return true if succeeded
  * @return false if failed
  */
-bool ArgumentParser::_parse_options(TokensView tokens) {
-    for (auto const& [i, token_pair] : tl::views::enumerate(tokens)) {
+bool ArgumentParser::_parse_options(TokensSpan tokens) {
+    for (auto const& [idx, token_pair] : tl::views::enumerate(tokens)) {
         auto const& token = token_pair.token;
         auto& parsed      = token_pair.parsed;
-        if (!has_option_prefix(token) || parsed) continue;
-        auto match = _match_option(token);
 
-        if (std::holds_alternative<size_t>(match)) {
+        if (!has_option_prefix(token) || tokens[idx].parsed) continue;
+
+        // special token: if the token is two prefix chars, everything after it is positional
+        if (token.size() == 2 && _pimpl->option_prefixes.find(token[0]) != std::string::npos && _pimpl->option_prefixes.find(token[1]) != std::string::npos) {
+            parsed = true;
+            return true;
+        }
+
+        // tries to match the token as a prefix to the full option name
+        auto match = _match_option(token);
+        if (auto p_arg_name = std::get_if<std::string>(&match)) {
+            if (!_parse_one_option(_get_arg(*p_arg_name), tokens.subspan(idx + 1))) {
+                return false;
+            }
+            parsed = true;
+            continue;
+        }
+        // check if the option is ambiguous
+        if (auto p_frequency = std::get_if<size_t>(&match)) {
+            assert(p_frequency != nullptr);
+
             // check if the argument is a number
-            if (dvlab::str::from_string<float>(token).has_value())
+            if (dvlab::str::from_string<float>(token).has_value()) {
                 continue;
+            }
             auto frequency = std::get<size_t>(match);
             assert(frequency != 1);
 
-            // If the option is unrecognized, skip to the next arg
-            // because it may be a positional argument
-            if (frequency == 0) continue;
-
-            // Else the option is ambiguous. Report the error and quit parsing
-            auto const matching_option_filter = [this, &token = token](std::string const& name) {
-                return has_option_prefix(name) && name.starts_with(token);
-            };
-            fmt::println(stderr, "Error: ambiguous option: \"{}\" could match {}",
-                         token, fmt::join(_pimpl->arguments | std::views::keys | std::views::filter(matching_option_filter), ", "));
-            return false;
+            // If the option is ambiguous, report the error and quit parsing
+            if (frequency > 0) {
+                auto const matching_option_filter = [this, &token = token](std::string const& name) {
+                    return has_option_prefix(name) && name.starts_with(token);
+                };
+                fmt::println(stderr, "Error: ambiguous option: \"{}\" could match {}",
+                             token, fmt::join(_pimpl->arguments | std::views::keys | std::views::filter(matching_option_filter), ", "));
+                return false;
+            }
         }
-        Argument& arg = _get_arg(std::get<std::string>(match));
+        // else the option is unrecognized. Tries to match the token with a single-char option
+        // for example, if the token is "-abc", then it will try to match "-a", "-b", and "-c",
+        // among which only the last one can have an subsequent argument.
 
-        if (arg.is_help_action()) {
-            this->print_help();
-            return false;  // break the parsing
+        auto const [single_char_options, remainder_token] = _explode_option(token);
+
+        for (auto const& [j, option] : tl::views::enumerate(single_char_options)) {
+            auto& arg = _get_arg(option);
+            if (j == single_char_options.size() - 1) {
+                if (remainder_token.empty()) {
+                    if (!_parse_one_option(arg, tokens.subspan(idx + 1))) {
+                        return false;
+                    }
+                } else {
+                    std::array<Token, 1> tmpToken{Token{remainder_token}};
+                    if (!_parse_one_option(arg, TokensSpan{tmpToken})) {
+                        return false;
+                    }
+                }
+            } else {
+                if (!_parse_one_option(arg, TokensSpan{})) {
+                    return false;
+                }
+            }
         }
 
-        if (arg.is_version_action()) {
-            this->print_version();
-            return false;  // break the parsing
-        }
-
-        parsed           = true;
-        auto parse_range = arg.get_parse_range(tokens.subspan(i + 1));
-        if (!arg.tokens_enough_to_parse(parse_range)) {
-            fmt::println(stderr, "Error: missing argument(s) for \"{}\": expected {}{} arguments!!",
-                         arg.get_name(), (arg.get_nargs().lower < arg.get_nargs().upper ? "at least " : ""), arg.get_nargs().lower);
-            return false;
-        }
-
-        if (!arg.take_action(parse_range)) {
-            return false;
-        }
-
-        if (!_no_conflict_with_parsed_arguments(arg)) return false;
-
-        arg.mark_as_parsed();  // if the options is present, no matter if there's any argument the follows, mark it as parsed
+        parsed = true;
     }
 
     return _all_required_options_are_parsed();
+}
+std::pair<std::vector<std::string>, std::string> ArgumentParser::_explode_option(std::string_view token) const {
+    std::vector<std::string> single_char_options;
+    std::string remainder_token;
+    for (auto const& [j, ch] : tl::views::enumerate(token.substr(1))) {
+        std::string const single_char_option{token[0], ch};
+        auto match = _match_option(single_char_option);
+        if (auto p_arg_name = std::get_if<std::string>(&match)) {
+            single_char_options.push_back(single_char_option);
+            // if the option need at least one argument, then the remainder of the token is the argument
+            if (_get_arg(*p_arg_name).get_nargs().lower > 0) {
+                remainder_token = token.substr(j + 2);
+                break;
+            }
+        }
+        // if we encounter a single-char that does not match any option, then everything after it is the argument for the last option
+        else if (auto p_frequency = std::get_if<size_t>(&match)) {
+            remainder_token = token.substr(j + 2);
+        }
+    }
+    return {single_char_options, remainder_token};
+}
+
+bool ArgumentParser::_parse_one_option(Argument& arg, TokensSpan tokens) {
+    auto parse_range = arg.get_parse_range(tokens);
+    if (arg.is_help_action()) {
+        this->print_help();
+        return false;  // break the parsing
+    }
+
+    if (arg.is_version_action()) {
+        this->print_version();
+        return false;  // break the parsing
+    }
+
+    if (!arg.tokens_enough_to_parse(parse_range)) {
+        fmt::println(stderr, "Error: missing argument(s) for \"{}\": expected {}{} arguments!!",
+                     arg.get_name(), (arg.get_nargs().lower < arg.get_nargs().upper ? "at least " : ""), arg.get_nargs().lower);
+        return false;
+    }
+
+    if (!arg.take_action(parse_range)) {
+        return false;
+    }
+
+    if (!_no_conflict_with_parsed_arguments(arg)) return false;
+
+    arg.mark_as_parsed();  // if the options is present, no matter if there's any argument the follows, mark it as parsed
+    return true;
 }
 
 /**
@@ -402,7 +469,7 @@ bool ArgumentParser::_parse_options(TokensView tokens) {
  * @return true if succeeded
  * @return false if failed
  */
-bool ArgumentParser::_parse_positional_arguments(TokensView tokens, std::vector<Token>& unrecognized) {
+bool ArgumentParser::_parse_positional_arguments(TokensSpan tokens, std::vector<Token>& unrecognized) {
     for (auto& [name, arg] : _pimpl->arguments) {
         if (arg.is_parsed() || has_option_prefix(name)) continue;
 

--- a/src/argparse/arg_parser.hpp
+++ b/src/argparse/arg_parser.hpp
@@ -125,10 +125,10 @@ public:
     [[nodiscard]] SubParsers add_subparsers();
 
     bool parse_args(std::vector<std::string> const& tokens);
-    bool parse_args(TokensView);
+    bool parse_args(TokensSpan);
 
     std::pair<bool, std::vector<Token>> parse_known_args(std::vector<std::string> const& tokens);
-    std::pair<bool, std::vector<Token>> parse_known_args(TokensView);
+    std::pair<bool, std::vector<Token>> parse_known_args(TokensSpan);
 
     bool analyze_options() const;
 
@@ -177,7 +177,7 @@ private:
 
     // pretty printing helpers
 
-    std::pair<bool, std::vector<Token>> _parse_known_args_impl(TokensView);
+    std::pair<bool, std::vector<Token>> _parse_known_args_impl(TokensSpan);
 
     void _activate_subparser(std::string_view name) {
         _pimpl->activated_subparser = name;
@@ -188,8 +188,10 @@ private:
 
     // parse subroutine
     std::string _get_activated_subparser_name() const { return _pimpl->activated_subparser.value_or(""); }
-    bool _parse_options(TokensView tokens);
-    bool _parse_positional_arguments(TokensView tokens, std::vector<Token>& unrecognized);
+    bool _parse_options(TokensSpan tokens);
+    bool _parse_one_option(Argument& arg, TokensSpan tokens);
+    std::pair<std::vector<std::string>, std::string> _explode_option(std::string_view token) const;
+    bool _parse_positional_arguments(TokensSpan tokens, std::vector<Token>& unrecognized);
     void _fill_unparsed_args_with_defaults();
 
     // parseOptions subroutine

--- a/src/argparse/arg_type.cpp
+++ b/src/argparse/arg_type.cpp
@@ -107,7 +107,7 @@ ArgType<std::string>::ConstraintType allowed_extension(std::vector<std::string> 
 ActionCallbackType store_true(ArgType<bool>& arg) {
     arg.default_value(false);
     arg.nargs(0ul);
-    return [&arg](TokensView) { arg.append_value(true); return true; };
+    return [&arg](TokensSpan) { arg.append_value(true); return true; };
 }
 
 /**
@@ -120,13 +120,13 @@ ActionCallbackType store_true(ArgType<bool>& arg) {
 ActionCallbackType store_false(ArgType<bool>& arg) {
     arg.default_value(true);
     arg.nargs(0ul);
-    return [&arg](TokensView) { arg.append_value(false); return true; };
+    return [&arg](TokensSpan) { arg.append_value(false); return true; };
 }
 
 ActionCallbackType help(ArgType<bool>& arg) {
     arg.mark_as_help_action();
     arg.nargs(0ul);
-    return [](TokensView) -> bool {
+    return [](TokensSpan) -> bool {
         return true;
     };
 }
@@ -134,7 +134,7 @@ ActionCallbackType help(ArgType<bool>& arg) {
 ActionCallbackType version(ArgType<bool>& arg) {
     arg.mark_as_version_action();
     arg.nargs(0ul);
-    return [](TokensView) -> bool {
+    return [](TokensSpan) -> bool {
         return true;
     };
 }

--- a/src/argparse/arg_type.hpp
+++ b/src/argparse/arg_type.hpp
@@ -52,7 +52,7 @@ enum class NArgsOption {
     zero_or_more
 };
 
-using ActionCallbackType = std::function<bool(TokensView)>;  // perform an action and return if it succeeds
+using ActionCallbackType = std::function<bool(TokensSpan)>;  // perform an action and return if it succeeds
 
 template <typename T>
 requires valid_argument_type<T>
@@ -76,7 +76,7 @@ public:
     ArgType& nargs(size_t l, size_t u);
     ArgType& nargs(NArgsOption opt);
 
-    inline bool take_action(TokensView tokens);
+    inline bool take_action(TokensSpan tokens);
     inline void reset();
 
     template <typename Ret>
@@ -356,7 +356,7 @@ void ArgType<T>::reset() {
  */
 template <typename T>
 requires valid_argument_type<T>
-bool ArgType<T>::take_action(TokensView tokens) {
+bool ArgType<T>::take_action(TokensSpan tokens) {
     assert(_action_callback != nullptr);
 
     return _action_callback(tokens);
@@ -374,7 +374,7 @@ bool ArgType<T>::take_action(TokensView tokens) {
 template <typename T>
 requires valid_argument_type<T>
 ActionCallbackType store(ArgType<T>& arg) {
-    return [&arg](TokensView tokens) -> bool {
+    return [&arg](TokensSpan tokens) -> bool {
         T tmp;
         for (auto& [token, parsed] : tokens) {
             if (!parse_from_string(tmp, token)) {
@@ -401,7 +401,7 @@ requires valid_argument_type<T>
 typename ArgType<T>::ActionType store_const(T const& const_value) {
     return [const_value](ArgType<T>& arg) -> ActionCallbackType {
         arg.nargs(0ul);
-        return [&arg, const_value](TokensView) { arg.append_value(const_value); return true; };
+        return [&arg, const_value](TokensSpan) { arg.append_value(const_value); return true; };
     };
 }
 

--- a/src/argparse/argument.cpp
+++ b/src/argparse/argument.cpp
@@ -25,7 +25,7 @@ void Argument::reset() {
  * @return true if action success, or
  * @return false if action failed or < l argument are available
  */
-bool Argument::take_action(TokensView tokens) {
+bool Argument::take_action(TokensSpan tokens) {
     if (!_pimpl->do_take_action(tokens) || !is_constraints_satisfied()) return false;
 
     return true;
@@ -37,7 +37,7 @@ bool Argument::take_action(TokensView tokens) {
  * @param tokens
  * @return TokensView
  */
-TokensView Argument::get_parse_range(TokensView tokens) const {
+TokensSpan Argument::get_parse_range(TokensSpan tokens) const {
     auto parse_start = std::ranges::find_if(
         tokens, [](Token& token) { return token.parsed == false; });
 
@@ -47,7 +47,7 @@ TokensView Argument::get_parse_range(TokensView tokens) const {
     return tokens.subspan(parse_start - std::begin(tokens), std::min(get_nargs().upper, static_cast<size_t>(parse_end - parse_start)));
 }
 
-bool Argument::tokens_enough_to_parse(TokensView tokens) const {
+bool Argument::tokens_enough_to_parse(TokensSpan tokens) const {
     return (tokens.size() >= get_nargs().lower);
 }
 /**

--- a/src/argparse/argument.hpp
+++ b/src/argparse/argument.hpp
@@ -64,8 +64,8 @@ public:
     bool is_version_action() const { return _pimpl->do_is_version_action(); }
     bool is_constraints_satisfied() const { return _pimpl->do_is_constraints_satisfied(); }
     bool is_parsed() const { return _pimpl->do_is_parsed(); }
-    TokensView get_parse_range(TokensView) const;
-    bool tokens_enough_to_parse(TokensView) const;
+    TokensSpan get_parse_range(TokensSpan) const;
+    bool tokens_enough_to_parse(TokensSpan) const;
 
     template <typename T>
     T get() const;
@@ -79,7 +79,7 @@ public:
 
     // action
     void reset();
-    bool take_action(TokensView tokens);
+    bool take_action(TokensSpan tokens);
     void mark_as_parsed() { _pimpl->do_mark_as_parsed(); }
 
 private:
@@ -105,7 +105,7 @@ private:
 
         virtual std::string do_to_string() const = 0;
 
-        virtual bool do_take_action(TokensView) = 0;
+        virtual bool do_take_action(TokensSpan) = 0;
         virtual void do_set_value_to_default()  = 0;
         virtual void do_reset()                 = 0;
     };
@@ -139,7 +139,7 @@ private:
 
         inline std::string do_to_string() const override { return fmt::format("{}", inner); }
 
-        inline bool do_take_action(TokensView tokens) override { return inner.take_action(tokens); }
+        inline bool do_take_action(TokensSpan tokens) override { return inner.take_action(tokens); }
         inline void do_set_value_to_default() override { return inner.set_value_to_default(); }
         inline void do_reset() override { inner.reset(); }
     };

--- a/src/zx/zx_cmd.cpp
+++ b/src/zx/zx_cmd.cpp
@@ -479,6 +479,7 @@ Command zxgraph_vertex_remove_cmd(ZXGraphMgr& zxgraph_mgr) {
     return Command{
         "remove",
         [&](ArgumentParser& parser) {
+            parser.description("remove vertices from ZXGraph");
             auto mutex = parser.add_mutually_exclusive_group().required(true);
 
             mutex.add_argument<size_t>("ids")

--- a/tests/cli/ref/cmd_help.log
+++ b/tests/cli/ref/cmd_help.log
@@ -36,10 +36,14 @@ Options:
 
 Subcommands:
 (add | remove)  
-    add  add vertices to ZXGraph 
+    add     add vertices to ZXGraph      
+    remove  remove vertices from ZXGraph 
 
 qsyn> zx vertex remove -h
 Usage: zx vertex remove [-h] ([<size_t ids>]... | -i)
+
+Description:
+  remove vertices from ZXGraph
 
 Positional Arguments:
   size_t  ids    the IDs of vertices to remove 


### PR DESCRIPTION
## Check List
1. [x] Does your submission pass tests by running `./RUN_TEST`?
2. [x] Have you linted your code locally with `./scripts/LINT` before submission?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!-- Link to specific issues where seems fit. -->

### Added
- Implemented #16.

### Changed
- 

### Fixed
- 

### Removed
- 