### PR TITLE
Feat/history only dump successful commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ FetchContent_Declare(
     SYSTEM
     GIT_REPOSITORY https://github.com/seleznevae/libfort.git
     GIT_TAG v0.4.2)
+set(FORT_ENABLE_TESTING OFF CACHE INTERNAL "")
 FetchContent_MakeAvailable(libfort)
 
 FetchContent_Declare(
@@ -66,7 +67,13 @@ FetchContent_Declare(
     SYSTEM
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
     GIT_TAG v1.12.0)
+set(SPDLOG_FMT_EXTERNAL ON CACHE INTERNAL "")
 FetchContent_MakeAvailable(spdlog)
+target_compile_definitions(
+    spdlog
+    PRIVATE
+    SPDLOG_SHORT_LEVEL_NAMES={\"[trace]\ \ \ \ \",\"[debug]\ \ \ \ \",\"[info]\ \ \ \ \ \",\"[warn]\ \ \ \ \ \",\"[error]\ \ \ \ \",\"[critical]\ \",\"\"})
+target_link_libraries(spdlog PRIVATE fmt::fmt)
 
 FetchContent_Declare(
     GSL
@@ -81,15 +88,6 @@ file(
     RELATIVE ${CMAKE_SOURCE_DIR}
     "src/**/*.cpp" "src/**/*.hpp" "src/qsyn/qsynrc.default")
 add_executable(${CMAKE_PROJECT_NAME} ${SOURCES})
-
-target_compile_definitions(spdlog PUBLIC SPDLOG_FMT_EXTERNAL=1)
-target_compile_definitions(
-    spdlog
-    PUBLIC
-    SPDLOG_SHORT_LEVEL_NAMES={\"[trace]\ \ \ \ \",\"[debug]\ \ \ \ \",\"[info]\ \ \ \ \ \",\"[warn]\ \ \ \ \ \",\"[error]\ \ \ \ \",\"[critical]\ \",\"\"}
-)
-
-target_link_libraries(spdlog PUBLIC fmt::fmt)
 
 target_compile_definitions(${CMAKE_PROJECT_NAME}
     PRIVATE QSYN_VERSION="v${CMAKE_PROJECT_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
 project(
     qsyn
     LANGUAGES CXX
-    VERSION 0.6.2)
+    VERSION 0.6.3)
 
 find_package(OpenMP REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Visualization functionalities of `qsyn` depend at runtime on the following depen
 
   ```sh
    ❯ ./qsyn
-   qsyn v0.6.2 - Copyright © 2022-2023, DVLab NTUEE.
+   qsyn v0.6.3 - Copyright © 2022-2023, DVLab NTUEE.
    Licensed under Apache 2.0 License.
    qsyn>
   ```
@@ -130,7 +130,7 @@ Visualization functionalities of `qsyn` depend at runtime on the following depen
 
   ```sh
   ❯ ./qsyn -f examples/synth.dof
-  qsyn v0.6.2 - DVLab NTUEE.
+  qsyn v0.6.3 - DVLab NTUEE.
   Licensed under Apache 2.0 License.
   qsyn> qcir read benchmark/zx/tof3.zx
   ```

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -230,6 +230,8 @@ private:
     size_t _get_last_token_pos(std::string_view str, char token = ' ') const;
 
     bool _move_cursor_to(size_t pos);
+    bool _to_prev_word();
+    bool _to_next_word();
     bool _delete_char();
     void _insert_char(char ch);
     void _delete_line();

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -134,8 +134,16 @@ public:
     void list_all_commands() const;
     void list_all_aliases() const;
     void list_all_variables() const;
-    void print_history(size_t n_print = SIZE_MAX, bool include_fails = false) const;
-    void write_history(std::filesystem::path const& filepath, size_t n_print = SIZE_MAX, bool append_quit = true, bool include_fails = false) const;
+
+    struct HistoryFilter {
+        bool success : 1;
+        bool error : 1;
+        bool unknown : 1;
+        bool interrupted : 1;
+    };
+
+    void print_history(size_t n_print = SIZE_MAX, HistoryFilter filter = {.success = true, .error = true, .unknown = true, .interrupted = true}) const;
+    void write_history(std::filesystem::path const& filepath, size_t n_print = SIZE_MAX, bool append_quit = true, HistoryFilter filter = {.success = true, .error = false, .unknown = false, .interrupted = false}) const;
     inline void clear_history() {
         _history.clear();
         _history_idx = 0;

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -238,6 +238,8 @@ private:
     void _replace_at_cursor(std::string_view old_str, std::string_view new_str);
     void _reprint_command();
     void _retrieve_history(size_t index);
+    size_t _prev_matching_history(size_t count = 1);
+    size_t _next_matching_history(size_t count = 1);
     void _add_to_history(HistoryEntry const& entry);
     void _replace_read_buffer_with_history();
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -137,8 +137,8 @@ public:
     void list_all_commands() const;
     void list_all_aliases() const;
     void list_all_variables() const;
-    void print_history(size_t n_print = SIZE_MAX) const;
-    void write_history(std::filesystem::path const& filepath, size_t n_print = SIZE_MAX, bool append_quit = true) const;
+    void print_history(size_t n_print = SIZE_MAX, bool include_fails = false) const;
+    void write_history(std::filesystem::path const& filepath, size_t n_print = SIZE_MAX, bool append_quit = true, bool include_fails = false) const;
     inline void clear_history() {
         _history.clear();
         _history_idx = 0;
@@ -203,7 +203,7 @@ private:
     void _replace_at_cursor(std::string_view old_str, std::string_view new_str);
     void _reprint_command();
     void _retrieve_history(size_t index);
-    bool _add_to_history(std::string_view input);
+    bool _add_to_history(std::string_view input, CmdExecResult result);
     void _replace_read_buffer_with_history();
 
     template <typename... Args>
@@ -232,7 +232,7 @@ private:
     std::string _read_buffer;
     size_t _cursor_position = 0;
 
-    std::vector<std::string> _history;
+    std::vector<std::pair<std::string, CmdExecResult>> _history;
     size_t _history_idx        = 0;
     size_t _tab_press_count    = 0;
     bool _listening_for_inputs = false;

--- a/src/cli/cli_char_def.hpp
+++ b/src/cli/cli_char_def.hpp
@@ -50,23 +50,29 @@ constexpr key_code_type arrow_left_key = 68 + arrow_key_flag;
 constexpr key_code_type arrow_key_begin{arrow_up_key};
 constexpr key_code_type arrow_key_end{arrow_left_key};
 
-//
-// -- MOD keys: 27 -> 91 -> {49-54} -> 126
-//    MOD_KEY = { INSERT, DELETE, HOME, END, PgUp, PgDown }
-//
-constexpr key_code_type mod_key_flag{1 << 9};
-constexpr key_code_type mod_key_int{91};
-constexpr key_code_type home_key{49 + mod_key_flag};
-constexpr key_code_type insert_key{50 + mod_key_flag};
-constexpr key_code_type delete_key{51 + mod_key_flag};
-constexpr key_code_type end_key{52 + mod_key_flag};
-constexpr key_code_type pg_up_key{53 + mod_key_flag};
-constexpr key_code_type pg_down_key{54 + mod_key_flag};
-constexpr key_code_type mod_key_begin{home_key};
-constexpr key_code_type mod_key_end{pg_down_key};
-constexpr key_code_type mod_key_dummy{126};
+// -- CTRL keys: 27 -> 91 -> {49-54} -> 126
+//    CTRL_KEY = { INSERT, DELETE, HOME, END, PgUp, PgDown }
 
-//
+constexpr key_code_type ctrl_key_flag{1 << 9};
+constexpr key_code_type ctrl_key_int = arrow_key_int;
+constexpr key_code_type home_key{49 + ctrl_key_flag};
+constexpr key_code_type insert_key{50 + ctrl_key_flag};
+constexpr key_code_type delete_key{51 + ctrl_key_flag};
+constexpr key_code_type end_key{52 + ctrl_key_flag};
+constexpr key_code_type pg_up_key{53 + ctrl_key_flag};
+constexpr key_code_type pg_down_key{54 + ctrl_key_flag};
+constexpr key_code_type ctrl_key_begin{home_key};
+constexpr key_code_type ctrl_key_end{pg_down_key};
+constexpr key_code_type ctrl_key_dummy{126};
+
+constexpr key_code_type alt_key_flag{1 << 10};
+constexpr key_code_type alt_key_int = arrow_key_int;
+constexpr key_code_type prev_word_key{98 + alt_key_flag};
+constexpr key_code_type next_word_key{102 + alt_key_flag};
+constexpr key_code_type alt_key_begin{prev_word_key};
+constexpr key_code_type alt_key_end{next_word_key};
+constexpr key_code_type alt_key_dummy{126};
+
 // [For undefined keys]
 constexpr key_code_type undefined_key{INT_MAX};
 

--- a/src/cli/cli_cmd.cpp
+++ b/src/cli/cli_cmd.cpp
@@ -160,8 +160,7 @@ Command help_cmd(CommandLineInterface& cli) {
                 command = cli.get_first_token(alias_replacement_string.value());
             }
 
-            auto e = cli.get_command(command);
-            if (e) {
+            if (auto e = cli.get_command(command)) {
                 e->print_help();
                 return CmdExecResult::done;
             }

--- a/src/cli/cli_cmd.cpp
+++ b/src/cli/cli_cmd.cpp
@@ -71,6 +71,22 @@ Command alias_cmd(CommandLineInterface& cli) {
         }};
 }
 
+Command echo_cmd() {
+    return {
+        "echo",
+        [](ArgumentParser& parser) {
+            parser.description("print the string to the standard output");
+
+            parser.add_argument<std::string>("message")
+                .nargs(NArgsOption::zero_or_more)
+                .help("the message to print");
+        },
+        [](ArgumentParser const& parser) {
+            fmt::println("{}", fmt::join(parser.get<std::vector<std::string>>("message"), " "));
+            return CmdExecResult::done;
+        }};
+}
+
 Command set_variable_cmd(CommandLineInterface& cli) {
     return {
         "set",
@@ -357,6 +373,7 @@ bool add_cli_common_cmds(dvlab::CommandLineInterface& cli) {
           cli.add_alias("unalias", "alias -d") &&
           cli.add_command(set_variable_cmd(cli)) &&
           cli.add_alias("unset", "set -d") &&
+          cli.add_command(echo_cmd()) &&
           cli.add_command(quit_cmd(cli)) &&
           cli.add_command(history_cmd(cli)) &&
           cli.add_command(help_cmd(cli)) &&

--- a/src/cli/cli_listen.cpp
+++ b/src/cli/cli_listen.cpp
@@ -326,9 +326,9 @@ void dvlab::CommandLineInterface::_retrieve_history(size_t index) {
     if (index < _history_idx) {                 // move up
         if (_history_idx == _history.size()) {  // move away from new input
             _temp_command_stored = true;
-            _history.emplace_back(_read_buffer, CmdExecResult::interrupted);
+            _history.emplace_back(_read_buffer, CmdExecResult::done);
         } else if (_temp_command_stored && _history_idx == _history.size() - 1)
-            _history.back().first = _read_buffer;  // => update it
+            _history.back().input = _read_buffer;  // => update it
     } else if (index > _history_idx) {             // move down
         if (_history_idx == _history.size() - _temp_command_stored ? 1 : 0) {
             detail::beep();
@@ -344,17 +344,10 @@ void dvlab::CommandLineInterface::_retrieve_history(size_t index) {
 
 /**
  * @brief Add the command in buffer to _history.
- *        This function trim the comment, leading/trailing whitespace of the entered comments
  *
  */
-bool dvlab::CommandLineInterface::_add_to_history(std::string_view input, CmdExecResult result) {
-    if (input.size()) {
-        _history.emplace_back(input, result);
-    }
-
-    _history_idx = int(_history.size());
-
-    return input.size() > 0;
+void dvlab::CommandLineInterface::_add_to_history(HistoryEntry const& entry) {
+    _history.emplace_back(entry);
 }
 
 /**
@@ -363,9 +356,9 @@ bool dvlab::CommandLineInterface::_add_to_history(std::string_view input, CmdExe
  */
 void dvlab::CommandLineInterface::_replace_read_buffer_with_history() {
     _delete_line();
-    _read_buffer = _history[_history_idx].first;
+    _read_buffer = _history[_history_idx].input;
     _print_if_echo("{}", _read_buffer);
-    _cursor_position = _history[_history_idx].first.size();
+    _cursor_position = _history[_history_idx].input.size();
 }
 
 /**

--- a/src/cli/cli_listen.cpp
+++ b/src/cli/cli_listen.cpp
@@ -326,10 +326,10 @@ void dvlab::CommandLineInterface::_retrieve_history(size_t index) {
     if (index < _history_idx) {                 // move up
         if (_history_idx == _history.size()) {  // move away from new input
             _temp_command_stored = true;
-            _history.emplace_back(_read_buffer);
+            _history.emplace_back(_read_buffer, CmdExecResult::interrupted);
         } else if (_temp_command_stored && _history_idx == _history.size() - 1)
-            _history.back() = _read_buffer;  // => update it
-    } else if (index > _history_idx) {       // move down
+            _history.back().first = _read_buffer;  // => update it
+    } else if (index > _history_idx) {             // move down
         if (_history_idx == _history.size() - _temp_command_stored ? 1 : 0) {
             detail::beep();
             return;
@@ -347,9 +347,9 @@ void dvlab::CommandLineInterface::_retrieve_history(size_t index) {
  *        This function trim the comment, leading/trailing whitespace of the entered comments
  *
  */
-bool dvlab::CommandLineInterface::_add_to_history(std::string_view input) {
+bool dvlab::CommandLineInterface::_add_to_history(std::string_view input, CmdExecResult result) {
     if (input.size()) {
-        _history.emplace_back(input);
+        _history.emplace_back(input, result);
     }
 
     _history_idx = int(_history.size());
@@ -363,9 +363,9 @@ bool dvlab::CommandLineInterface::_add_to_history(std::string_view input) {
  */
 void dvlab::CommandLineInterface::_replace_read_buffer_with_history() {
     _delete_line();
-    _read_buffer = _history[_history_idx];
+    _read_buffer = _history[_history_idx].first;
     _print_if_echo("{}", _read_buffer);
-    _cursor_position = _history[_history_idx].size();
+    _cursor_position = _history[_history_idx].first.size();
 }
 
 /**

--- a/src/cli/cli_print.cpp
+++ b/src/cli/cli_print.cpp
@@ -54,7 +54,7 @@ void dvlab::CommandLineInterface::list_all_variables() const {
  *
  * @param nPrint
  */
-void dvlab::CommandLineInterface::print_history(size_t n_print) const {
+void dvlab::CommandLineInterface::print_history(size_t n_print, bool include_fails) const {
     assert(_temp_command_stored == false);
 
     if (n_print > _history.size())
@@ -64,12 +64,21 @@ void dvlab::CommandLineInterface::print_history(size_t n_print) const {
         fmt::println(("Empty command history!!"));
         return;
     }
-    for (auto const& [i, history] : _history | std::views::drop(_history.size() - n_print) | tl::views::enumerate) {
-        fmt::println("{:>4}: {}", i, history);
+    auto hist_range = _history |
+                      std::views::drop(_history.size() - n_print) |
+                      tl::views::enumerate |
+                      std::views::filter([&include_fails](auto const& history) {
+                          return include_fails || history.second.second == CmdExecResult::done;
+                      });
+    for (auto const& [i, history] : hist_range) {
+        fmt::println("{:>4}: {}", i, history.first);
+    }
+    if (!include_fails) {
+        spdlog::info("Use -f, --include-fails to include failed commands in history");
     }
 }
 
-void dvlab::CommandLineInterface::write_history(std::filesystem::path const& filepath, size_t n_print, bool append_quit) const {
+void dvlab::CommandLineInterface::write_history(std::filesystem::path const& filepath, size_t n_print, bool append_quit, bool include_fails) const {
     assert(_temp_command_stored == false);
 
     if (n_print > _history.size())
@@ -84,8 +93,13 @@ void dvlab::CommandLineInterface::write_history(std::filesystem::path const& fil
         spdlog::info("Empty command history!!");
         return;
     }
-    for (auto const& history : _history | std::views::drop(_history.size() - n_print)) {
-        fmt::println(ofs, "{}", history);
+    auto hist_range = _history |
+                      std::views::drop(_history.size() - n_print) |
+                      std::views::filter([&include_fails](auto const& history) {
+                          return include_fails || history.second == CmdExecResult::done;
+                      });
+    for (auto const& history : hist_range) {
+        fmt::println(ofs, "{}", history.first);
     }
     if (append_quit) {
         fmt::println(ofs, "quit -f");

--- a/src/cli/cli_print.cpp
+++ b/src/cli/cli_print.cpp
@@ -68,10 +68,10 @@ void dvlab::CommandLineInterface::print_history(size_t n_print, bool include_fai
                       std::views::drop(_history.size() - n_print) |
                       tl::views::enumerate |
                       std::views::filter([&include_fails](auto const& history) {
-                          return include_fails || history.second.second == CmdExecResult::done;
+                          return include_fails || history.second.status == CmdExecResult::done;
                       });
     for (auto const& [i, history] : hist_range) {
-        fmt::println("{:>4}: {}", i, history.first);
+        fmt::println("{:>4}: {}", i, history.input);
     }
     if (!include_fails) {
         spdlog::info("Use -f, --include-fails to include failed commands in history");
@@ -96,10 +96,10 @@ void dvlab::CommandLineInterface::write_history(std::filesystem::path const& fil
     auto hist_range = _history |
                       std::views::drop(_history.size() - n_print) |
                       std::views::filter([&include_fails](auto const& history) {
-                          return include_fails || history.second == CmdExecResult::done;
+                          return include_fails || history.status == CmdExecResult::done;
                       });
     for (auto const& history : hist_range) {
-        fmt::println(ofs, "{}", history.first);
+        fmt::println(ofs, "{}", history.input);
     }
     if (append_quit) {
         fmt::println(ofs, "quit -f");

--- a/src/qsyn/qsyn_main.cpp
+++ b/src/qsyn/qsyn_main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char** argv) {
         auto const result = cli.execute_one_line(cmd_stream, !quiet);
 
         if (result == dvlab::CmdExecResult::quit) {
-            return 0;
+            return cli.get_last_return_code();
         }
     }
 
@@ -109,11 +109,9 @@ int main(int argc, char** argv) {
         auto const result = cli.source_dofile(args[0], std::ranges::subrange(args.begin() + 1, args.end()), !quiet);
 
         if (result == dvlab::CmdExecResult::quit) {
-            return 0;
+            return cli.get_last_return_code();
         }
     }
 
-    auto const result = cli.start_interactive();
-
-    return static_cast<std::underlying_type_t<dvlab::CmdExecResult>>(result);
+    return cli.start_interactive();
 }


### PR DESCRIPTION
## Check List

1. [x] Does your submission pass tests by running `make test`?
2. [x] If you have specified a [no ci] tag, does your submission also pass tests by running `make test-docker`?
3. [x] Have you linted your code locally with `make lint` before submission?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!-- Link to specific issues where it seems fit. -->

### Added

- use Alt + left/right to navigate between words
- up/down/pgup/pgdn now only retrieves history with matching suffixes
- `history` now show/output only successful commands ; use `history [<+|-><u|e|i|s>]` to toggle the history outputs

### Changed

-

### Fixed

- CMakeList spdlog variable pollution
- CMakeList compiling unnecessary libfort test files

### Removed

-
