### PR TITLE
:bug: Fix xt::linalg::trace with correct return type

### DIFF
--- a/src/tensor/tensor.hpp
+++ b/src/tensor/tensor.hpp
@@ -311,15 +311,11 @@ std::complex<double> Tensor<DT>::determinant() const {
 template <typename DT>
 std::complex<double> Tensor<DT>::trace() {
     assert(dimension() == 2);
-    return _tensor(0, 0) + _tensor(1, 1);
-    // TODO - Change to xt
-    // return xt::linalg::trace(_tensor).at(0);
+    return xt::sum(xt::diagonal(_tensor))();
 }
 
 template <typename DT>
 auto Tensor<DT>::eigen() {
-    // TODO - Check the return type, may be std::pair<value, vector>
-    // TODO -
     return xt::linalg::eig(_tensor);
 }
 


### PR DESCRIPTION
## Check List

1. [ ] Does your submission pass tests by running `make test`?
2. [ ] If you have specified a [no ci] tag, does your submission also pass tests by running `make test-docker`?
3. [ ] Have you linted your code locally with `make lint` before submission?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!-- Link to specific issues where it seems fit. -->

### Added

-

### Changed

-

### Fixed

-

### Removed

-
