### PR TITLE
fix: update cli behavior to make it more shell-like

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -323,6 +323,13 @@ std::string CommandLineInterface::get_last_token(std::string_view str) const {
     return std::string{str.substr(_get_last_token_pos(str))};
 }
 
+CmdExecResult CommandLineInterface::get_last_return_status() const {
+    for (auto const& history : _history | std::views::reverse) {
+        if (history.status != CmdExecResult::quit) return history.status;
+    }
+    return CmdExecResult::done;
+}
+
 size_t CommandLineInterface::_get_first_token_pos(std::string_view str, char token) const {
     auto first_space_pos = str.find_first_of(token);
     while (first_space_pos != std::string::npos && _is_escaped(str, first_space_pos)) {

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -41,13 +41,31 @@ struct HeterogenousStringHash {
 class CommandLineInterface;
 
 // intentionally not using enum class because it is used as the return value of main
-enum CmdExecResult : int {
-    done          = EXIT_SUCCESS,
-    error         = EXIT_FAILURE,
-    cmd_not_found = 127,
-    interrupted   = 130,
-    quit          = 131
+enum class CmdExecResult {
+    done,
+    error,
+    cmd_not_found,
+    interrupted,
+    quit
 };
+
+constexpr int get_exit_code(CmdExecResult result) {
+    switch (result) {
+        case CmdExecResult::done:
+            return EXIT_SUCCESS;
+        case CmdExecResult::error:
+            return EXIT_FAILURE;
+        case CmdExecResult::cmd_not_found:
+            return 127;
+        case CmdExecResult::interrupted:
+            return 130;
+        case CmdExecResult::quit:
+            return EXIT_SUCCESS;
+        default:
+            return EXIT_FAILURE;
+    }
+}
+
 namespace detail {
 
 inline void beep() {
@@ -167,7 +185,7 @@ public:
     std::string get_first_token(std::string_view str) const;
     std::string get_last_token(std::string_view str) const;
 
-    CmdExecResult get_last_return_code() const { return _history.empty() ? CmdExecResult::done : _history.back().status; }
+    CmdExecResult get_last_return_status() const;
 
 private:
     enum class TabActionResult {

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -11,9 +11,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
-#include <fstream>
 #include <functional>
-#include <map>
 #include <memory>
 #include <stack>
 #include <string>

--- a/src/cli/cli_exec.cpp
+++ b/src/cli/cli_exec.cpp
@@ -28,7 +28,7 @@ CmdExecResult CommandLineInterface::start_interactive() {
         status = this->execute_one_line(std::cin, true);
     }
 
-    return get_last_return_code();
+    return get_last_return_status();
 }
 
 /**

--- a/src/qsyn/qsyn_main.cpp
+++ b/src/qsyn/qsyn_main.cpp
@@ -89,21 +89,15 @@ int main(int argc, char** argv) {
             cli.add_variable(std::to_string(i + 1), arg);
         }
 
-        auto const result = cli.execute_one_line(cmd_stream, !quiet);
-
-        if (result == dvlab::CmdExecResult::quit) {
-            return dvlab::get_exit_code(cli.get_last_return_status());
-        }
+        cli.execute_one_line(cmd_stream, !quiet);
+        return dvlab::get_exit_code(cli.get_last_return_status());
     }
 
     if (parser.parsed("--file")) {
         auto args = parser.get<std::vector<std::string>>("--file");
 
-        auto const result = cli.source_dofile(args[0], std::ranges::subrange(args.begin() + 1, args.end()), !quiet);
-
-        if (result == dvlab::CmdExecResult::quit) {
-            return dvlab::get_exit_code(cli.get_last_return_status());
-        }
+        cli.source_dofile(args[0], std::ranges::subrange(args.begin() + 1, args.end()), !quiet);
+        return dvlab::get_exit_code(cli.get_last_return_status());
     }
 
     return dvlab::get_exit_code(cli.start_interactive());

--- a/src/qsyn/qsyn_main.cpp
+++ b/src/qsyn/qsyn_main.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
         auto const result = cli.execute_one_line(cmd_stream, !quiet);
 
         if (result == dvlab::CmdExecResult::quit) {
-            return cli.get_last_return_code();
+            return dvlab::get_exit_code(cli.get_last_return_status());
         }
     }
 
@@ -102,9 +102,9 @@ int main(int argc, char** argv) {
         auto const result = cli.source_dofile(args[0], std::ranges::subrange(args.begin() + 1, args.end()), !quiet);
 
         if (result == dvlab::CmdExecResult::quit) {
-            return cli.get_last_return_code();
+            return dvlab::get_exit_code(cli.get_last_return_status());
         }
     }
 
-    return cli.start_interactive();
+    return dvlab::get_exit_code(cli.start_interactive());
 }


### PR DESCRIPTION
## Check List

1. [x] Does your submission pass tests by running `make test`?
2. [x] If you have specified a [no ci] tag, does your submission also pass tests by running `make test-docker`?
3. [x] Have you linted your code locally with `make lint` before submission?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!-- Link to specific issues where it seems fit. -->

### Added

-

### Changed

- automatically quit after execution if qsyn is launched with -c or -f flag
- decouple exit code with `CmdExecResult`

### Fixed

- "quit -f" now returns the exit code of the previous command instead of 131

### Removed

-
