### PR TITLE
Addressing `-Werror=restrict`: Harmonizing C++ `std::string` with C-Style Strings

### DIFF
--- a/src/cli/cli_tab.cpp
+++ b/src/cli/cli_tab.cpp
@@ -232,12 +232,17 @@ dvlab::CommandLineInterface::TabActionResult dvlab::CommandLineInterface::_match
     // no auto complete : list matched files
 
     for (auto& file : files) {
-        for (size_t i = 0; i < file.size(); ++i) {
-            if (_is_special_char(file[i])) {
-                file.insert(i, "\\");
-                ++i;
+        std::string new_file;
+        bool modified = false;
+        for (char c : file) {
+            if (_is_special_char(c)) {
+                new_file += '\\';
+                modified = true;
             }
+            new_file += c;
         }
+        if (modified)
+            file = std::move(new_file);
     }
 
     for (auto& file : files) {

--- a/src/util/phase.cpp
+++ b/src/util/phase.cpp
@@ -27,7 +27,7 @@ std::string Phase::get_ascii_string() const {
         str += std::to_string(_rational.numerator()) + "*";
     str += "pi";
     if (_rational.denominator() != 1)
-        str += "/" + std::to_string(_rational.denominator());
+        str += std::string("/") + std::to_string(_rational.denominator());
     return str;
 }
 
@@ -42,7 +42,7 @@ std::string Phase::get_print_string() const {
                : _rational.numerator() == -1
                    ? "-"
                    : std::to_string(_rational.numerator())) +
-           ((_rational.numerator() != 0) ? "\u03C0" : "") + ((_rational.denominator() != 1) ? ("/" + std::to_string(_rational.denominator())) : "");
+           ((_rational.numerator() != 0) ? std::string("\u03C0") : std::string("")) + ((_rational.denominator() != 1) ? (std::string("/") + std::to_string(_rational.denominator())) : std::string(""));
 }
 
 std::ostream& operator<<(std::ostream& os, dvlab::Phase const& p) {

--- a/src/util/text_format.cpp
+++ b/src/util/text_format.cpp
@@ -144,7 +144,9 @@ fmt::text_style ls_color(fs::path const& path) {
         return ls_color_internal("ex");
     }
 
-    return ls_color_internal("*" + path.extension().string());
+    std::string ret = std::string("*");
+    ret += path.extension().string();
+    return ls_color_internal(ret);
 }
 
 }  // namespace fmt_ext

--- a/vendor/tqdm/tqdm.hpp
+++ b/vendor/tqdm/tqdm.hpp
@@ -126,7 +126,7 @@ public:
     void set_theme_vertical() { bars = {"▁", "▂", "▃", "▄", "▅", "▆", "▇", "█", "█"}; }
     void set_theme_basic() {
         bars      = {" ", " ", " ", " ", " ", " ", " ", " ", "#"};
-        right_pad = "|";
+        right_pad = std::string("|");
     }
     void set_label(std::string label_) { label = label_; }
     void disable_colors() {


### PR DESCRIPTION
## Check List

1. [x] Does your submission pass tests by running `make test`?
2. [x] If you have specified a [no ci] tag, does your submission also pass tests by running `make test-docker`?
3. [x] Have you linted your code locally with `make lint` before submission?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!-- Link to specific issues where it seems fit. -->


### Fixed
Resolved `std::string` operation errors caused by the warning flag "`-Werror=restrict`" when using G++ 12.2.
The issue arose from mixing traditional C-style string formatting with C++ `std::string` operations. These modifications ensure that all C-style strings are properly converted to `std::string` objects.

Affected Files:
1. `src/cli/cli_tab.cpp`
2. `src/util/phase.cpp`
3. `src/util/text_format.cpp`
4. `vendor/tqdm/tqdm.hpp`


