### PR TITLE
Add solovay_kitaev_all support for RX/RY/RZ gate decomposition

### DIFF
--- a/src/tensor/solovay_kitaev_all.cpp
+++ b/src/tensor/solovay_kitaev_all.cpp
@@ -1,0 +1,120 @@
+/****************************************************************************
+  PackageName  [ tensor ]
+  Synopsis     [ Apply Solovay-Kitaev decomposition to all rotation gates in QCir ]
+  Author       [ Design Verification Lab ]
+  Copyright    [ Copyright(c) 2025 DVLab, GIEE, NTU, Taiwan ]
+****************************************************************************/
+
+#include "./solovay_kitaev_all.hpp"
+
+#include <numbers>
+#include <complex>
+#include <iostream>
+
+#include "cmd/qcir_mgr.hpp"
+#include "qcir/basic_gate_type.hpp"
+#include "qcir/qcir_gate.hpp"
+#include "tensor/solovay_kitaev.hpp"
+#include "tensor/qtensor.hpp"
+#include "tensor/tensor.hpp"
+
+using qsyn::qcir::QCirMgr;
+
+namespace qsyn::tensor {
+
+namespace {
+
+QTensor<double> get_rx_tensor(double theta) {
+    using namespace std::complex_literals;
+    return QTensor<double>({
+        {std::complex<double>(std::cos(theta / 2.0), 0), std::complex<double>(0, -std::sin(theta / 2.0))},
+        {std::complex<double>(0, -std::sin(theta / 2.0)), std::complex<double>(std::cos(theta / 2.0), 0)}
+    });
+}
+
+QTensor<double> get_ry_tensor(double theta) {
+    return QTensor<double>({
+        {std::complex<double>(std::cos(theta / 2.0), 0.0), std::complex<double>(-std::sin(theta / 2.0), 0.0)},
+        {std::complex<double>(std::sin(theta / 2.0), 0.0), std::complex<double>(std::cos(theta / 2.0), 0.0)}
+    });
+}
+
+QTensor<double> get_rz_tensor(double theta) {
+    using namespace std::complex_literals;
+    return QTensor<double>({
+            {std::exp(-1.0i * theta / 2.0), 0.0},
+            {0.0, std::exp(1.0i * theta / 2.0)}
+    });
+}
+
+}  // namespace
+
+/**
+ * @brief Apply Solovay-Kitaev decomposition to all rotation gates
+ *
+ * @param mgr Quantum circuit manager
+ * @param depth Gate list depth
+ * @param recursion Number of recursive refinements
+ */
+void solovay_kitaev_all(QCirMgr& mgr, size_t depth, size_t recursion) {
+    using QCirGate = qsyn::qcir::QCirGate;
+
+    std::vector<QCirGate*> new_gates;
+
+    for (auto* gate : mgr.get()->get_gates()) {
+        auto const& op = gate->get_operation();
+
+        QTensor<double> u;
+        double theta;
+        bool match = false;
+
+        if (op.is<qsyn::qcir::RXGate>()) {
+            auto rat = op.get_underlying<qsyn::qcir::RXGate>().get_phase().get_rational();
+            theta = std::numbers::pi * static_cast<double>(rat.numerator()) / static_cast<double>(rat.denominator());
+            u = get_rx_tensor(theta);
+            match = true;
+        } else if (op.is<qsyn::qcir::RYGate>()) {
+            auto rat = op.get_underlying<qsyn::qcir::RYGate>().get_phase().get_rational();
+            theta = std::numbers::pi * static_cast<double>(rat.numerator()) / static_cast<double>(rat.denominator());
+            u = get_ry_tensor(theta);
+            match = true;
+        } else if (op.is<qsyn::qcir::RZGate>()) {
+            auto rat = op.get_underlying<qsyn::qcir::RZGate>().get_phase().get_rational();
+            theta = std::numbers::pi * static_cast<double>(rat.numerator()) / static_cast<double>(rat.denominator());
+            u = get_rz_tensor(theta);
+            match = true;
+        }
+
+        if (match) {
+            size_t qubit = gate->get_qubit(0);
+            SolovayKitaev sk(depth, recursion);
+            auto opt_circuit = sk.solovay_kitaev_decompose(u);
+
+            if (opt_circuit) {
+                for (const auto& g : opt_circuit->get_gates()) {
+                    auto shifted_qubits = g->get_qubits();
+                    for (auto& q : shifted_qubits) q = qubit;
+                    new_gates.emplace_back(new QCirGate(g->get_operation(), shifted_qubits));
+                }
+            } else {
+                spdlog::warn("Failed to decompose gate at qubit {}", qubit);
+                new_gates.push_back(gate);
+            }
+        } else {
+            new_gates.push_back(gate);
+        }
+    }
+
+    mgr.get()->reset();
+    size_t max_qubit = 0;
+    for (auto* g : new_gates) {
+        for (auto q : g->get_qubits())
+            max_qubit = std::max(max_qubit, q);
+    }
+
+    mgr.get()->add_qubits(max_qubit + 1);
+    for (auto* g : new_gates)
+        mgr.get()->append(g->get_operation(), g->get_qubits());
+}
+
+}  // namespace qsyn::tensor

--- a/src/tensor/solovay_kitaev_all.hpp
+++ b/src/tensor/solovay_kitaev_all.hpp
@@ -1,0 +1,29 @@
+/****************************************************************************
+  PackageName  [ tensor ]
+  Synopsis     [ Apply Solovay-Kitaev decomposition to all rotation gates in QCir ]
+  Author       [ Design Verification Lab ]
+  Copyright    [ Copyright(c) 2025 DVLab, GIEE, NTU, Taiwan ]
+****************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+
+#include "cmd/qcir_mgr.hpp"
+
+namespace qsyn {
+
+namespace tensor {
+
+/**
+ * @brief Apply Solovay-Kitaev decomposition to all RX/RY/RZ gates in the given QCirMgr
+ *
+ * @param mgr The quantum circuit manager
+ * @param depth Depth of the gate approximation tree
+ * @param recursion Number of recursive refinements (SK recursion level)
+ */
+void solovay_kitaev_all(qcir::QCirMgr& mgr, size_t depth, size_t recursion);
+
+}  // namespace tensor
+
+}  // namespace qsyn


### PR DESCRIPTION
## Check List

1. [ ✅ ] Does your submission pass tests by running `make test`?
2. [ ] If you have specified a [no ci] tag, does your submission also pass tests by running `make test-docker`?
         No [no ci] tag.
4. [ ] Have you linted your code locally with `make lint` before submission?
         Ultimately, the terminal output contains only warnings.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!-- Link to specific issues where it seems fit. -->

### Added

I added two files:
" qsyn/src/tensor/solovay_kitaev_all.cpp "
" qsyn/src/tensor/solovay_kitaev_all.hpp "


-

### Changed

I changed the  file "qsyn/src/cmd/conversion.cpp"
```

#include "tensor/solovay_kitaev_all.hpp"
  ...
Command sk_all_cmd(){ ... }
  ...
bool add_conversion_cmds(...){
  ...
    cli.add_command(sk_all_cmd(qcir_mgr)) &&
  ...
}

```

-

### Fixed

-

### Removed

-
