### PR TITLE
Move filenames and procedures to the data structure manager level

### DIFF
--- a/src/cmd/conversion_cmd.cpp
+++ b/src/cmd/conversion_cmd.cpp
@@ -75,9 +75,9 @@ Command convert_from_qcir_cmd(
                 if (graph.has_value()) {
                     zxgraph_mgr.add(zxgraph_mgr.get_next_id(), std::make_unique<qsyn::zx::ZXGraph>(std::move(graph.value())));
 
-                    zxgraph_mgr.get()->set_filename(qcir_mgr.get()->get_filename());
-                    zxgraph_mgr.get()->add_procedures(qcir_mgr.get()->get_procedures());
-                    zxgraph_mgr.get()->add_procedure("QC2ZX");
+                    zxgraph_mgr.set_filename(qcir_mgr.get_filename());
+                    zxgraph_mgr.add_procedures(qcir_mgr.get_procedures());
+                    zxgraph_mgr.add_procedure("QC2ZX");
                 }
                 return CmdExecResult::done;
             }
@@ -90,9 +90,9 @@ Command convert_from_qcir_cmd(
                     tensor_mgr.add(tensor_mgr.get_next_id());
                     tensor_mgr.set(std::make_unique<qsyn::tensor::QTensor<double>>(std::move(tensor.value())));
 
-                    tensor_mgr.get()->set_filename(qcir_mgr.get()->get_filename());
-                    tensor_mgr.get()->add_procedures(qcir_mgr.get()->get_procedures());
-                    tensor_mgr.get()->add_procedure("QC2TS");
+                    tensor_mgr.set_filename(qcir_mgr.get_filename());
+                    tensor_mgr.add_procedures(qcir_mgr.get_procedures());
+                    tensor_mgr.add_procedure("QC2TS");
                 }
                 return CmdExecResult::done;
             }
@@ -103,9 +103,9 @@ Command convert_from_qcir_cmd(
                 if (tableau.has_value()) {
                     tableau_mgr.add(tableau_mgr.get_next_id(), std::make_unique<tableau::Tableau>(std::move(tableau.value())));
 
-                    tableau_mgr.get()->set_filename(qcir_mgr.get()->get_filename());
-                    tableau_mgr.get()->add_procedures(qcir_mgr.get()->get_procedures());
-                    tableau_mgr.get()->add_procedure("QC2TABL");
+                    tableau_mgr.set_filename(qcir_mgr.get_filename());
+                    tableau_mgr.add_procedures(qcir_mgr.get_procedures());
+                    tableau_mgr.add_procedure("QC2TABL");
                 }
                 return CmdExecResult::done;
             }
@@ -151,16 +151,16 @@ Command convert_from_zx_cmd(zx::ZXGraphMgr& zxgraph_mgr, QCirMgr& qcir_mgr, tens
                 qcir::QCir* result = ext.extract();
                 if (result != nullptr) {
                     qcir_mgr.add(qcir_mgr.get_next_id(), std::unique_ptr<qcir::QCir>(result));
-                    qcir_mgr.get()->set_filename(zxgraph_mgr.get()->get_filename());
-                    qcir_mgr.get()->add_procedures(zxgraph_mgr.get()->get_procedures());
+                    qcir_mgr.set_filename(zxgraph_mgr.get_filename());
+                    qcir_mgr.add_procedures(zxgraph_mgr.get_procedures());
                     if (!extractor::EXTRACTOR_CONFIG.permute_qubits) {
                         spdlog::warn("The extracted circuit is up to a qubit permutation.");
                         spdlog::warn("Remaining permutation information is in ZXGraph id {}.", zxgraph_mgr.get_next_id());
                         zxgraph_mgr.add(zxgraph_mgr.get_next_id(), std::make_unique<zx::ZXGraph>(std::move(target)));
-                        zxgraph_mgr.get()->add_procedure("ZX2QC-Unpermuted");
-                        qcir_mgr.get()->add_procedure("ZX2QC-Unpermuted");
+                        zxgraph_mgr.add_procedure("ZX2QC-Unpermuted");
+                        qcir_mgr.add_procedure("ZX2QC-Unpermuted");
                     } else
-                        qcir_mgr.get()->add_procedure("ZX2QC");
+                        qcir_mgr.add_procedure("ZX2QC");
 
                     assert(std::ranges::all_of(qcir_mgr.get()->get_gates(), [&](auto* gate) { return gate->get_id() == qcir_mgr.get()->get_gate(gate->get_id())->get_id(); }));
                 }
@@ -173,9 +173,9 @@ Command convert_from_zx_cmd(zx::ZXGraphMgr& zxgraph_mgr, QCirMgr& qcir_mgr, tens
                 if (tensor.has_value()) {
                     tensor_mgr.add(tensor_mgr.get_next_id(), std::make_unique<qsyn::tensor::QTensor<double>>(std::move(tensor.value())));
 
-                    tensor_mgr.get()->set_filename(zxgraph_mgr.get()->get_filename());
-                    tensor_mgr.get()->add_procedures(zxgraph_mgr.get()->get_procedures());
-                    tensor_mgr.get()->add_procedure("ZX2TS");
+                    tensor_mgr.set_filename(zxgraph_mgr.get_filename());
+                    tensor_mgr.add_procedures(zxgraph_mgr.get_procedures());
+                    tensor_mgr.add_procedure("ZX2TS");
                 }
                 return CmdExecResult::done;
             }
@@ -206,9 +206,9 @@ Command convert_from_tensor_cmd(tensor::TensorMgr& tensor_mgr, QCirMgr& qcir_mgr
 
                 if (result) {
                     qcir_mgr.add(qcir_mgr.get_next_id(), std::make_unique<qcir::QCir>(std::move(*result)));
-                    qcir_mgr.get()->add_procedures(tensor_mgr.get()->get_procedures());
-                    qcir_mgr.get()->add_procedure("TS2QC");
-                    qcir_mgr.get()->set_filename(tensor_mgr.get()->get_filename());
+                    qcir_mgr.add_procedures(tensor_mgr.get_procedures());
+                    qcir_mgr.add_procedure("TS2QC");
+                    qcir_mgr.set_filename(tensor_mgr.get_filename());
                 }
 
                 return CmdExecResult::done;
@@ -316,9 +316,9 @@ Command convert_from_tableau_cmd(tableau::TableauMgr& tableau_mgr, qcir::QCirMgr
                 if (qcir.has_value()) {
                     qcir_mgr.add(qcir_mgr.get_next_id(), std::make_unique<qcir::QCir>(std::move(qcir.value())));
 
-                    qcir_mgr.get()->set_filename(tableau_mgr.get()->get_filename());
-                    qcir_mgr.get()->add_procedures(tableau_mgr.get()->get_procedures());
-                    qcir_mgr.get()->add_procedure("TABL2QC");
+                    qcir_mgr.set_filename(tableau_mgr.get_filename());
+                    qcir_mgr.add_procedures(tableau_mgr.get_procedures());
+                    qcir_mgr.add_procedure("TABL2QC");
                 }
 
                 return CmdExecResult::done;
@@ -368,9 +368,9 @@ Command sk_decompose_cmd(qsyn::tensor::TensorMgr& tensor_mgr, QCirMgr& qcir_mgr)
 
                 if (result) {
                     qcir_mgr.add(qcir_mgr.get_next_id(), std::make_unique<qcir::QCir>(std::move(*result)));
-                    qcir_mgr.get()->add_procedures(tensor_mgr.get()->get_procedures());
-                    qcir_mgr.get()->add_procedure("Solovay-Kitaev");
-                    qcir_mgr.get()->set_filename(tensor_mgr.get()->get_filename());
+                    qcir_mgr.add_procedures(tensor_mgr.get_procedures());
+                    qcir_mgr.add_procedure("Solovay-Kitaev");
+                    qcir_mgr.set_filename(tensor_mgr.get_filename());
                 }
 
                 return CmdExecResult::done;

--- a/src/cmd/device_mgr.hpp
+++ b/src/cmd/device_mgr.hpp
@@ -21,13 +21,17 @@ using DeviceMgr = dvlab::utils::DataStructureManager<Device>;
 }  // namespace qsyn::device
 
 template <>
-inline std::string dvlab::utils::data_structure_info_string(qsyn::device::Device const& t) {
+inline std::string dvlab::utils::data_structure_info_string(dvlab::utils::DataStructureManager<qsyn::device::Device> const& mgr, size_t id) {
+    auto* device = mgr.find_by_id(id);
+    if (!device) return {};
     return fmt::format("{:<19} #Q: {:>4}",
-                       t.get_name().substr(0, 19),  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
-                       t.get_num_qubits());
+                       device->get_name().substr(0, 19),  // NOLINT(cppcoreguidelines-avoid-magic-numbers)
+                       device->get_num_qubits());
 }
 
 template <>
-inline std::string dvlab::utils::data_structure_name(qsyn::device::Device const& t) {
-    return t.get_name();
+inline std::string dvlab::utils::data_structure_name(dvlab::utils::DataStructureManager<qsyn::device::Device> const& mgr, size_t id) {
+    auto* device = mgr.find_by_id(id);
+    if (!device) return {};
+    return device->get_name();
 }

--- a/src/cmd/duostra_cmd.cpp
+++ b/src/cmd/duostra_cmd.cpp
@@ -256,6 +256,8 @@ Command duostra_cmd(qcir::QCirMgr& qcir_mgr, device::DeviceMgr& device_mgr) {
                            //                            }
                            // #endif
                            qcir::QCir* logical_qcir = qcir_mgr.get();
+                           auto filename            = qcir_mgr.get_filename();
+                           auto procedures          = qcir_mgr.get_procedures();
                            Duostra duo{logical_qcir,
                                        *device_mgr.get(),
                                        DUOSTRA_CONFIG,
@@ -272,9 +274,9 @@ Command duostra_cmd(qcir::QCirMgr& qcir_mgr, device::DeviceMgr& device_mgr) {
                            auto const id = qcir_mgr.get_next_id();
                            qcir_mgr.add(id, std::move(duo.get_physical_circuit()));
 
-                           qcir_mgr.get()->set_filename(logical_qcir->get_filename());
-                           qcir_mgr.get()->add_procedures(logical_qcir->get_procedures());
-                           qcir_mgr.get()->add_procedure("Duostra");
+                           qcir_mgr.set_filename(filename);
+                           qcir_mgr.add_procedures(procedures);
+                           qcir_mgr.add_procedure("Duostra");
 
                            return CmdExecResult::done;
                        }};

--- a/src/cmd/qcir/optimizer_cmd.cpp
+++ b/src/cmd/qcir/optimizer_cmd.cpp
@@ -67,9 +67,10 @@ Command qcir_optimize_cmd(QCirMgr& qcir_mgr) {
                 if (!dvlab::utils::mgr_has_data(qcir_mgr)) return CmdExecResult::error;
                 Optimizer optimizer;
                 std::optional<QCir> result;
-                std::string procedure_str{};
+                std::string const filename          = qcir_mgr.get_filename();
+                std::vector<std::string> procedures = qcir_mgr.get_procedures();
 
-                enum class Strategy {
+                enum struct Strategy : std::uint8_t {
                     basic,
                     teleport,
                     blaqsmith
@@ -88,21 +89,22 @@ Command qcir_optimize_cmd(QCirMgr& qcir_mgr) {
                 switch (strategy) {
                     case Strategy::teleport:
                         phase_teleport(*qcir_mgr.get());
-                        procedure_str = "Phase Teleport";
+                        procedures.emplace_back("Phase Teleport");
                         break;
                     case Strategy::blaqsmith:
                         optimize_2q_count(*qcir_mgr.get(), parser.get<double>("--init-temp"), 2, 2);
-                        procedure_str = "Blaqsmith";
+                        procedures.emplace_back("Blaqsmith");
+
                         break;
                     case Strategy::basic: {
                         if (parser.get<bool>("--tech") || !qcir_mgr.get()->get_gate_set().empty()) {
-                            result        = optimizer.trivial_optimization(*qcir_mgr.get());
-                            procedure_str = "Tech Optimize";
+                            result = optimizer.trivial_optimization(*qcir_mgr.get());
+                            procedures.emplace_back("Tech Optimize");
                         } else {
-                            result        = optimizer.basic_optimization(*qcir_mgr.get(), {.doSwap          = !parser.get<bool>("--physical"),
-                                                                                           .maxIter         = 1000,
-                                                                                           .printStatistics = parser.get<bool>("--statistics")});
-                            procedure_str = "Optimize";
+                            result = optimizer.basic_optimization(*qcir_mgr.get(), {.doSwap          = !parser.get<bool>("--physical"),
+                                                                                    .maxIter         = 1000,
+                                                                                    .printStatistics = parser.get<bool>("--statistics")});
+                            procedures.emplace_back("Optimize");
                         }
                         if (result == std::nullopt) {
                             spdlog::error("Fail to optimize circuit.");
@@ -117,9 +119,10 @@ Command qcir_optimize_cmd(QCirMgr& qcir_mgr) {
                     }
                 }
                 if (stop_requested()) {
-                    procedure_str += "[INT]";
+                    procedures.emplace_back("[INT]");
                 }
-                qcir_mgr.get()->add_procedure(procedure_str);
+                qcir_mgr.set_filename(filename);
+                qcir_mgr.set_procedures(procedures);
 
                 return CmdExecResult::done;
             }};

--- a/src/cmd/qcir/oracle_cmd.cpp
+++ b/src/cmd/qcir/oracle_cmd.cpp
@@ -117,9 +117,9 @@ Command qcir_oracle_cmd(QCirMgr& qcir_mgr) {
             if (qcir.has_value()) {
                 qcir_mgr.add(qcir_mgr.get_next_id(), std::make_unique<QCir>(std::move(qcir.value())));
                 if (parser.parsed("--xag")) {
-                    qcir_mgr.get()->set_filename(parser.get<std::string>("--xag"));
+                    qcir_mgr.set_filename(parser.get<std::string>("--xag"));
                 } else if (parser.parsed("--tt")) {
-                    qcir_mgr.get()->set_filename(parser.get<std::string>("--tt"));
+                    qcir_mgr.set_filename(parser.get<std::string>("--tt"));
                 }
             }
 

--- a/src/cmd/qcir_cmd.cpp
+++ b/src/cmd/qcir_cmd.cpp
@@ -146,7 +146,7 @@ dvlab::Command qcir_read_cmd(QCirMgr& qcir_mgr) {
             } else {
                 qcir_mgr.set(std::make_unique<QCir>(std::move(*qcir)));
             }
-            qcir_mgr.get()->set_filename(std::filesystem::path{filepath}.stem());
+            qcir_mgr.set_filename(std::filesystem::path{filepath}.stem());
             return CmdExecResult::done;
         }};
 }
@@ -592,9 +592,9 @@ dvlab::Command qcir_translate_cmd(QCirMgr& qcir_mgr) {
                     spdlog::error("Translation fails!!");
                     return CmdExecResult::error;
                 }
-                std::string const filename = qcir_mgr.get()->get_filename();
+                std::string const filename = qcir_mgr.get_filename();
                 qcir_mgr.set(std::make_unique<QCir>(*std::move(translated_qcir)));
-                qcir_mgr.get()->set_filename(filename);
+                qcir_mgr.set_filename(filename);
                 return CmdExecResult::done;
             }};
 }

--- a/src/cmd/qcir_mgr.hpp
+++ b/src/cmd/qcir_mgr.hpp
@@ -21,12 +21,12 @@ using QCirMgr = dvlab::utils::DataStructureManager<QCir>;
 }  // namespace qsyn::qcir
 
 template <>
-inline std::string dvlab::utils::data_structure_info_string(qsyn::qcir::QCir const& t) {
-    return fmt::format("{:<19} {}", t.get_filename().substr(0, 19),
-                       fmt::join(t.get_procedures(), " ➔ "));
+inline std::string dvlab::utils::data_structure_info_string(dvlab::utils::DataStructureManager<qsyn::qcir::QCir> const& mgr, size_t id) {
+    return fmt::format("{:<19} {}", mgr.get_filename(id).substr(0, 19),
+                       fmt::join(mgr.get_procedures(id), " ➔ "));
 }
 
 template <>
-inline std::string dvlab::utils::data_structure_name(qsyn::qcir::QCir const& t) {
-    return t.get_filename();
+inline std::string dvlab::utils::data_structure_name(dvlab::utils::DataStructureManager<qsyn::qcir::QCir> const& mgr, size_t id) {
+    return mgr.get_filename(id);
 }

--- a/src/cmd/tableau_cmd.cpp
+++ b/src/cmd/tableau_cmd.cpp
@@ -294,25 +294,25 @@ dvlab::Command tableau_optimization_cmd(TableauMgr& tableau_mgr) {
                     break;
                 case OptimizationMethod::collapse:
                     collapse(*tableau_mgr.get());
-                    tableau_mgr.get()->add_procedure("collapse");
+                    tableau_mgr.add_procedure("collapse");
                     break;
                 case OptimizationMethod::t_merge:
                     merge_rotations(*tableau_mgr.get());
-                    tableau_mgr.get()->add_procedure("MergeT");
+                    tableau_mgr.add_procedure("MergeT");
                     break;
                 case OptimizationMethod::internal_h_opt:
                     minimize_internal_hadamards(*tableau_mgr.get());
-                    tableau_mgr.get()->add_procedure("InternalHOpt");
+                    tableau_mgr.add_procedure("InternalHOpt");
                     break;
                 case OptimizationMethod::phase_polynomial_optimization:
                     do_phase_polynomial_optimization();
-                    tableau_mgr.get()->add_procedure("PhasePolyOpt");
+                    tableau_mgr.add_procedure("PhasePolyOpt");
                     break;
                 case OptimizationMethod::matroid_partition:
                     if (!do_matroid_partition()) {
                         return dvlab::CmdExecResult::error;
                     }
-                    tableau_mgr.get()->add_procedure("MatroidPartition");
+                    tableau_mgr.add_procedure("MatroidPartition");
                     break;
             }
 

--- a/src/cmd/tableau_mgr.hpp
+++ b/src/cmd/tableau_mgr.hpp
@@ -21,12 +21,12 @@ using TableauMgr = dvlab::utils::DataStructureManager<Tableau>;
 }  // namespace qsyn::tableau
 
 template <>
-inline std::string dvlab::utils::data_structure_info_string(qsyn::tableau::Tableau const& t) {
-    return fmt::format("{:<19} {}", t.get_filename().substr(0, 19),
-                       fmt::join(t.get_procedures(), " ➔ "));
+inline std::string dvlab::utils::data_structure_info_string(dvlab::utils::DataStructureManager<qsyn::tableau::Tableau> const& mgr, size_t id) {
+    return fmt::format("{:<19} {}", mgr.get_filename(id).substr(0, 19),
+                       fmt::join(mgr.get_procedures(id), " ➔ "));
 }
 
 template <>
-inline std::string dvlab::utils::data_structure_name(qsyn::tableau::Tableau const& t) {
-    return t.get_filename();
+inline std::string dvlab::utils::data_structure_name(dvlab::utils::DataStructureManager<qsyn::tableau::Tableau> const& mgr, size_t id) {
+    return mgr.get_filename(id);
 }

--- a/src/cmd/tensor_mgr.hpp
+++ b/src/cmd/tensor_mgr.hpp
@@ -23,14 +23,16 @@ using TensorMgr = dvlab::utils::DataStructureManager<QTensor<double>>;
 }  // namespace qsyn::tensor
 
 template <>
-inline std::string dvlab::utils::data_structure_info_string(qsyn::tensor::QTensor<double> const& tensor) {
+inline std::string dvlab::utils::data_structure_info_string(dvlab::utils::DataStructureManager<qsyn::tensor::QTensor<double>> const& mgr, size_t id) {
+    auto* tensor = mgr.find_by_id(id);
+    if (!tensor) return {};
     return fmt::format("{:<19} #Dim: {}   {}",
-                       tensor.get_filename().substr(0, 19),
-                       tensor.dimension(),
-                       fmt::join(tensor.get_procedures(), " ➔ "));
+                       mgr.get_filename(id).substr(0, 19),
+                       tensor->dimension(),
+                       fmt::join(mgr.get_procedures(id), " ➔ "));
 }
 
 template <>
-inline std::string dvlab::utils::data_structure_name(qsyn::tensor::QTensor<double> const& tensor) {
-    return tensor.get_filename();
+inline std::string dvlab::utils::data_structure_name(dvlab::utils::DataStructureManager<qsyn::tensor::QTensor<double>> const& mgr, size_t id) {
+    return mgr.get_filename(id);
 }

--- a/src/cmd/zx/simp_cmd.cpp
+++ b/src/cmd/zx/simp_cmd.cpp
@@ -101,7 +101,7 @@ Command zxgraph_optimize_cmd(zx::ZXGraphMgr& zxgraph_mgr) {
                     procedure_str += "[INT]";
                 }
 
-                zxgraph_mgr.get()->add_procedure(procedure_str);
+                zxgraph_mgr.add_procedure(procedure_str);
                 return CmdExecResult::done;
             }};
 }

--- a/src/cmd/zx_cmd.cpp
+++ b/src/cmd/zx_cmd.cpp
@@ -258,7 +258,7 @@ Command zxgraph_read_cmd(ZXGraphMgr& zxgraph_mgr) {
                 } else {
                     zxgraph_mgr.add(zxgraph_mgr.get_next_id(), std::make_unique<ZXGraph>(std::move(graph.value())));
                 }
-                zxgraph_mgr.get()->set_filename(std::filesystem::path{filepath}.stem());
+                zxgraph_mgr.set_filename(std::filesystem::path{filepath}.stem());
                 return CmdExecResult::done;
             }};
 }

--- a/src/cmd/zxgraph_mgr.hpp
+++ b/src/cmd/zxgraph_mgr.hpp
@@ -17,12 +17,12 @@ using ZXGraphMgr = dvlab::utils::DataStructureManager<ZXGraph>;
 }  // namespace qsyn::zx
 
 template <>
-inline std::string dvlab::utils::data_structure_info_string(qsyn::zx::ZXGraph const& t) {
-    return fmt::format("{:<19} {}", t.get_filename().substr(0, 19),
-                       fmt::join(t.get_procedures(), " ➔ "));
+inline std::string dvlab::utils::data_structure_info_string(dvlab::utils::DataStructureManager<qsyn::zx::ZXGraph> const& mgr, size_t id) {
+    return fmt::format("{:<19} {}", mgr.get_filename(id).substr(0, 19),
+                       fmt::join(mgr.get_procedures(id), " ➔ "));
 }
 
 template <>
-inline std::string dvlab::utils::data_structure_name(qsyn::zx::ZXGraph const& t) {
-    return t.get_filename();
+inline std::string dvlab::utils::data_structure_name(dvlab::utils::DataStructureManager<qsyn::zx::ZXGraph> const& mgr, size_t id) {
+    return mgr.get_filename(id);
 }

--- a/src/qcir/optimizer/basic_optimization.cpp
+++ b/src/qcir/optimizer/basic_optimization.cpp
@@ -111,8 +111,6 @@ QCir Optimizer::_parse_once(QCir const& qcir, bool reversed, bool do_minimize_cz
     }
 
     QCir result = _build_from_storage(qcir.get_num_qubits(), reversed);
-    result.set_filename(qcir.get_filename());
-    result.add_procedures(qcir.get_procedures());
 
     for (size_t t = 0; t < _xs.size(); ++t) {
         if (!_xs[t]) continue;

--- a/src/qcir/optimizer/trivial_optimization.cpp
+++ b/src/qcir/optimizer/trivial_optimization.cpp
@@ -32,8 +32,6 @@ std::optional<QCir> Optimizer::trivial_optimization(QCir const& qcir) {
     reset(qcir);
     QCir result{qcir.get_num_qubits()};
 
-    result.set_filename(qcir.get_filename());
-    result.add_procedures(qcir.get_procedures());
     result.set_gate_set(qcir.get_gate_set());
 
     for (auto gate : qcir.get_gates()) {
@@ -164,7 +162,6 @@ size_t match_gate_sequence(std::vector<Operation> const& type_seq,
 QCir replace_single_qubit_gate_sequence(QCir& qcir, QubitIdType qubit, size_t gate_num,
                                         size_t seq_len, std::vector<Operation> const& seq) {
     QCir replaced;
-    replaced.add_procedures(qcir.get_procedures());
     replaced.add_qubits(qcir.get_num_qubits());
     replaced.set_gate_set(qcir.get_gate_set());
 

--- a/src/qcir/qcir.cpp
+++ b/src/qcir/qcir.cpp
@@ -71,9 +71,6 @@ QCir::QCir(QCir const& other) {
                              other.get_gates() |
                              views::transform(
                                  [](QCirGate* g) { return g->get_id(); }));
-
-    this->set_filename(other._filename);
-    this->add_procedures(other._procedures);
 }
 /**
  * @brief Get Gate.

--- a/src/qcir/qcir.hpp
+++ b/src/qcir/qcir.hpp
@@ -79,9 +79,7 @@ public:
     void swap(QCir& other) noexcept {
         std::swap(_gate_id, other._gate_id);
         std::swap(_dirty, other._dirty);
-        std::swap(_filename, other._filename);
         std::swap(_gate_set, other._gate_set);
-        std::swap(_procedures, other._procedures);
         std::swap(_qubits, other._qubits);
         std::swap(_gate_list, other._gate_list);
         std::swap(_id_to_gates, other._id_to_gates);
@@ -109,17 +107,10 @@ public:
     }
 
     QCirGate* get_gate(std::optional<size_t> gid) const;
-    std::string get_filename() const { return _filename; }
-    std::vector<std::string> const& get_procedures() const { return _procedures; }
     std::string get_gate_set() const { return _gate_set; }
 
     bool is_empty() const { return _qubits.empty() || _id_to_gates.empty(); }
 
-    void set_filename(std::string f) { _filename = std::move(f); }
-    void add_procedures(std::vector<std::string> const& ps) {
-        _procedures.insert(_procedures.end(), ps.begin(), ps.end());
-    }
-    void add_procedure(std::string const& p) { _procedures.emplace_back(p); }
     void set_gate_set(std::string g) { _gate_set = std::move(g); }
 
     void reset();
@@ -180,13 +171,11 @@ public:
 
     // additional APIs to make qcir::QCir an qcir::Operation
     std::string get_type() const { return "qcir"; }
-    std::string get_repr() const { return _filename; }
+    std::string get_repr() const { return "qcir"; }
 
 private:
     size_t _gate_id = 0;
-    std::string _filename;
     std::string _gate_set;
-    std::vector<std::string> _procedures;
     std::vector<QCirQubit> _qubits;
     dvlab::utils::ordered_hashmap<size_t, std::unique_ptr<QCirGate>> _id_to_gates;
     std::unordered_map<size_t, std::vector<std::optional<size_t>>> _predecessors;

--- a/src/tableau/tableau.hpp
+++ b/src/tableau/tableau.hpp
@@ -117,23 +117,6 @@ public:
         return _subtableaux[idx];
     }
 
-    auto get_filename() const {
-        return _filename;
-    }
-    auto set_filename(std::string const& filename) {
-        _filename = filename;
-    }
-
-    auto get_procedures() const {
-        return _procedures;
-    }
-    auto add_procedure(std::string const& procedure) {
-        _procedures.push_back(procedure);
-    }
-    auto add_procedures(std::vector<std::string> const& procedures) {
-        _procedures.insert(_procedures.end(), procedures.begin(), procedures.end());
-    }
-
     Tableau& h(size_t qubit) noexcept override;
     Tableau& s(size_t qubit) noexcept override;
     Tableau& cx(size_t control, size_t target) noexcept override;
@@ -141,8 +124,6 @@ public:
 private:
     std::vector<SubTableau> _subtableaux;
     std::size_t _n_qubits;
-    std::string _filename;
-    std::vector<std::string> _procedures;
 };
 
 void adjoint_inplace(SubTableau& subtableau);

--- a/src/tensor/qtensor.hpp
+++ b/src/tensor/qtensor.hpp
@@ -88,13 +88,6 @@ public:
     template <typename U>
     friend bool is_equivalent(QTensor<U> const& t1, QTensor<U> const& t2, U eps /* = 1e-6*/);
 
-    void set_filename(std::string const& f) { _filename = f; }
-    void add_procedures(std::vector<std::string> const& ps) { _procedures.insert(_procedures.end(), ps.begin(), ps.end()); }
-    void add_procedure(std::string_view p) { _procedures.emplace_back(p); }
-
-    std::string get_filename() const { return _filename; }
-    std::vector<std::string> const& get_procedures() const { return _procedures; }
-
     QTensor<T> to_matrix();
     QTensor<T> to_matrix(TensorAxisList const& out, TensorAxisList const& in) { return Tensor<std::complex<T>>::to_matrix(out, in); }
 

--- a/src/util/data_structure_manager.hpp
+++ b/src/util/data_structure_manager.hpp
@@ -9,37 +9,75 @@
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
 
+#include <map>
 #include <memory>
 #include <string>
-
-#include "./ordered_hashmap.hpp"
+#include <vector>
 
 namespace dvlab {
 
 namespace utils {
 
+// Forward declaration of DataStructureManager (without requires clause for now)
 template <typename T>
-std::string data_structure_info_string(T const& t);
+class DataStructureManager;
+
+// Forward declarations for function templates
+template <typename T>
+std::string data_structure_info_string(DataStructureManager<T> const& mgr, size_t id);
 
 template <typename T>
-std::string data_structure_name(T const& t);
+std::string data_structure_name(DataStructureManager<T> const& mgr, size_t id);
 
 template <typename T>
-concept manager_manageable = requires {
-    { data_structure_info_string(std::declval<T>()) } -> std::convertible_to<std::string>;
-    { data_structure_name(std::declval<T>()) } -> std::convertible_to<std::string>;
+struct ManagerItemAndAttrs {  // NOLINT(cppcoreguidelines-special-member-functions)
+                              // : copy-swap idiom
+    std::unique_ptr<T> data;
+    std::string filename;
+    std::vector<std::string> procedures;
+
+    ManagerItemAndAttrs() : data{nullptr} {}
+
+    ManagerItemAndAttrs(std::unique_ptr<T> d)
+        : data{std::move(d)} {}
+
+    ManagerItemAndAttrs(std::unique_ptr<T> d, std::string f, std::vector<std::string> p)
+        : data{std::move(d)}, filename{std::move(f)}, procedures{std::move(p)} {}
+
+    ManagerItemAndAttrs(ManagerItemAndAttrs const& other)
+        : data{other.data ? std::make_unique<T>(*other.data) : nullptr},
+          filename{other.filename},
+          procedures{other.procedures} {}
+
+    ManagerItemAndAttrs(ManagerItemAndAttrs&& other) noexcept = default;
+
+    ~ManagerItemAndAttrs() = default;
+
+    ManagerItemAndAttrs& operator=(ManagerItemAndAttrs copy) {
+        swap(copy);
+        return *this;
+    }
+
+    void swap(ManagerItemAndAttrs& other) noexcept {
+        std::swap(data, other.data);
+        std::swap(filename, other.filename);
+        std::swap(procedures, other.procedures);
+    }
+
+    friend void swap(ManagerItemAndAttrs& a, ManagerItemAndAttrs& b) noexcept {
+        a.swap(b);
+    }
 };
 
 template <typename T>
-requires manager_manageable<T>
 class DataStructureManager {  // NOLINT(hicpp-special-member-functions, cppcoreguidelines-special-member-functions) : copy-swap idiom
 public:
     DataStructureManager(std::string_view name) : _type_name{name} {}
     virtual ~DataStructureManager() = default;
 
     DataStructureManager(DataStructureManager const& other) : _next_id{other._next_id}, _focused_id{other._focused_id} {
-        for (auto& [id, data] : other._list) {
-            _list.emplace(id, std::make_unique<T>(*data));
+        for (auto& [id, item] : other._list) {
+            _list.emplace(id, item);
         }
     }
     DataStructureManager(DataStructureManager&& other) noexcept = default;
@@ -69,13 +107,18 @@ public:
 
     size_t get_next_id() const { return _next_id; }
 
-    T* get() const { return size() ? _list.at(_focused_id).get() : nullptr; }
+    T* get() const { return size() ? _list.at(_focused_id).data.get() : nullptr; }
 
     void set_by_id(size_t id, std::unique_ptr<T> t) {
         if (_list.contains(id)) {
             spdlog::info("Note: Replacing {} {}...", _type_name, id);
+            // Preserve filename and procedures when replacing
+            auto filename   = _list.at(id).filename;
+            auto procedures = _list.at(id).procedures;
+            _list.insert_or_assign(id, ManagerItemAndAttrs<T>{std::move(t), std::move(filename), std::move(procedures)});
+        } else {
+            _list.insert_or_assign(id, ManagerItemAndAttrs<T>{std::move(t)});
         }
-        _list.insert_or_assign(id, std::move(t));
     }
 
     void set(std::unique_ptr<T> t) {
@@ -87,7 +130,7 @@ public:
     size_t focused_id() const { return _focused_id; }
 
     T* add(size_t id) {
-        _list.emplace(id, std::make_unique<T>());
+        _list.emplace(id, ManagerItemAndAttrs<T>{std::make_unique<T>()});
         _focused_id = id;
         if (id == _next_id || _next_id < id) _next_id = id + 1;
 
@@ -97,7 +140,7 @@ public:
     }
 
     T* add(size_t id, std::unique_ptr<T> t) {
-        _list.emplace(id, std::move(t));
+        _list.emplace(id, ManagerItemAndAttrs<T>{std::move(t)});
         _focused_id = id;
         if (id == _next_id || _next_id < id) _next_id = id + 1;
 
@@ -140,10 +183,12 @@ public:
             spdlog::error("Cannot copy {0}: The {0} list is empty!!", _type_name);
             return;
         }
-        auto copy = std::make_unique<T>(*get());
+        auto const& source_item = _list.at(_focused_id);
+        auto copy_data          = std::make_unique<T>(*source_item.data);
+        ManagerItemAndAttrs<T> copy_item{std::move(copy_data), source_item.filename, source_item.procedures};
 
         if (_next_id <= new_id) _next_id = new_id + 1;
-        _list.insert_or_assign(new_id, std::move(copy));
+        _list.insert_or_assign(new_id, std::move(copy_item));
 
         spdlog::info("Successfully copied {0} {1} to {0} {2}", _type_name, _focused_id, new_id);
         checkout(new_id);
@@ -154,21 +199,21 @@ public:
             _print_id_does_not_exist_error_msg();
             return nullptr;
         }
-        return _list.at(id).get();
+        return _list.at(id).data.get();
     }
 
     void print_manager() const {
         fmt::println("-> #{}: {}", _type_name, this->size());
         if (this->size()) {
-            auto name = data_structure_name(*get());
+            auto name = data_structure_name(*this, _focused_id);
             fmt::println("-> Now focused on: {} {}{}", _type_name, _focused_id, name.empty() ? "" : fmt::format(" ({})", name));
         }
     }
 
     void print_list() const {
         if (this->size()) {
-            for (auto& [id, data] : _list) {
-                fmt::println("{} {}    {}", (id == _focused_id ? "★" : " "), id, data_structure_info_string(*data.get()));
+            for (auto& [id, item] : _list) {
+                fmt::println("{} {}    {}", (id == _focused_id ? "★" : " "), id, data_structure_info_string(*this, id));
             }
         } else {
             fmt::println("The {} list is empty", _type_name);
@@ -177,7 +222,7 @@ public:
 
     void print_focus() const {
         if (this->size()) {
-            auto name = data_structure_name(*get());
+            auto name = data_structure_name(*this, _focused_id);
             fmt::println("-> Now focused on: {} {}{}", _type_name, _focused_id, name.empty() ? "" : fmt::format(" ({})", name));
         } else {
             fmt::println("The {} list is empty", _type_name);
@@ -186,15 +231,109 @@ public:
 
     std::string get_type_name() const { return _type_name; }
 
+    // Filename access methods
+    std::string get_filename(size_t id) const {
+        if (!is_id(id)) {
+            _print_id_does_not_exist_error_msg();
+            return {};
+        }
+        return _list.at(id).filename;
+    }
+
+    std::string get_filename() const {
+        return size() ? get_filename(_focused_id) : std::string{};
+    }
+
+    void set_filename(size_t id, std::string const& filename) {
+        if (!is_id(id)) {
+            _print_id_does_not_exist_error_msg();
+            return;
+        }
+        _list.at(id).filename = filename;
+    }
+
+    void set_filename(std::string const& filename) {
+        if (size()) {
+            set_filename(_focused_id, filename);
+        }
+    }
+
+    // Procedures access methods
+    std::vector<std::string> const& get_procedures(size_t id) const {
+        if (!is_id(id)) {
+            _print_id_does_not_exist_error_msg();
+            static std::vector<std::string> const empty;
+            return empty;
+        }
+        return _list.at(id).procedures;
+    }
+
+    std::vector<std::string> const& get_procedures() const {
+        if (size()) {
+            return get_procedures(_focused_id);
+        }
+        static std::vector<std::string> const empty;
+        return empty;
+    }
+
+    void add_procedure(size_t id, std::string procedure) {
+        if (!is_id(id)) {
+            _print_id_does_not_exist_error_msg();
+            return;
+        }
+        _list.at(id).procedures.push_back(std::move(procedure));
+    }
+
+    void add_procedure(std::string procedure) {
+        if (size()) {
+            add_procedure(_focused_id, std::move(procedure));
+        }
+    }
+
+    void add_procedures(size_t id, std::vector<std::string> const& procedures) {
+        if (!is_id(id)) {
+            _print_id_does_not_exist_error_msg();
+            return;
+        }
+        _list.at(id).procedures.insert(_list.at(id).procedures.end(), procedures.begin(), procedures.end());
+    }
+
+    void add_procedures(std::vector<std::string> const& procedures) {
+        if (size()) {
+            add_procedures(_focused_id, procedures);
+        }
+    }
+
+    void set_procedures(size_t id, std::vector<std::string> const& procedures) {
+        if (!is_id(id)) {
+            _print_id_does_not_exist_error_msg();
+            return;
+        }
+        _list.at(id).procedures = procedures;
+    }
+
+    void set_procedures(std::vector<std::string> const& procedures) {
+        if (size()) {
+            set_procedures(_focused_id, procedures);
+        }
+    }
+
 private:
     size_t _next_id    = 0;
     size_t _focused_id = 0;
-    ordered_hashmap<size_t, std::unique_ptr<T>> _list;
+    std::map<size_t, ManagerItemAndAttrs<T>> _list;
     std::string _type_name;
 
     void _print_id_does_not_exist_error_msg() const {
         fmt::println(stderr, "Error: The ID provided does not exist!!");
     }
+};
+
+// Concept definition - must come after DataStructureManager is defined
+template <typename T>
+concept manager_manageable = requires {
+    { data_structure_info_string(std::declval<DataStructureManager<T> const&>(), std::declval<size_t>()) } -> std::convertible_to<std::string>;
+    { data_structure_name(std::declval<DataStructureManager<T> const&>(), std::declval<size_t>()) } -> std::convertible_to<std::string>;
 };
 
 }  // namespace utils

--- a/src/zx/zxgraph.cpp
+++ b/src/zx/zxgraph.cpp
@@ -52,7 +52,7 @@ ZXGraph::ZXGraph(ZXVertexList const& vertices,
     }
 }
 
-ZXGraph::ZXGraph(ZXGraph const& other) : _filename{other._filename}, _procedures{other._procedures}, _next_v_id(other._next_v_id) {
+ZXGraph::ZXGraph(ZXGraph const& other) : _next_v_id(other._next_v_id) {
     std::unordered_map<ZXVertex*, ZXVertex*> old_to_new_vertex_map;
 
     for (auto& v : other.get_vertices()) {

--- a/src/zx/zxgraph.hpp
+++ b/src/zx/zxgraph.hpp
@@ -140,8 +140,6 @@ public:
 
     void release() {
         _next_v_id = 0;
-        _filename  = "";
-        _procedures.clear();
         _inputs.clear();
         _outputs.clear();
         _vertices.clear();
@@ -152,8 +150,6 @@ public:
 
     void swap(ZXGraph& other) noexcept {
         std::swap(_next_v_id, other._next_v_id);
-        std::swap(_filename, other._filename);
-        std::swap(_procedures, other._procedures);
         std::swap(_inputs, other._inputs);
         std::swap(_outputs, other._outputs);
         std::swap(_vertices, other._vertices);
@@ -194,19 +190,6 @@ public:
     size_t num_outputs() const { return get_outputs().size(); }
     size_t num_vertices() const { return get_vertices().size(); }
     size_t num_neighbors(ZXVertex* v) const { return v->_neighbors.size(); }
-
-    // file and procedure related functions
-    // may be moved to manager class in the future
-    void set_filename(std::string const& f) { _filename = f; }
-    void add_procedures(std::vector<std::string> const& ps) {
-        _procedures.insert(std::end(_procedures), std::begin(ps), std::end(ps));
-    }
-    void add_procedure(std::string_view p) { _procedures.emplace_back(p); }
-
-    std::string get_filename() const { return _filename; }
-    std::vector<std::string> const& get_procedures() const {
-        return _procedures;
-    }
 
     // attributes
     bool is_neighbor(ZXVertex* v1, ZXVertex* v2) const {
@@ -377,8 +360,6 @@ public:
 
 private:
     mutable size_t _next_v_id = 0;
-    std::string _filename;
-    std::vector<std::string> _procedures;
     ZXVertexList _inputs;
     ZXVertexList _outputs;
     ZXVertexList _vertices;


### PR DESCRIPTION
# Check List

1. [x] Does your submission pass tests by running `make test`?
2. [x] If you have specified a [no ci] tag, does your submission also pass tests by running `make test-docker`?
3. [x] Have you linted your code locally with `make lint` before submission?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!-- Link to specific issues where it seems fit. -->

# Refactored

Moved the `_filename` and `_procedures` fields to the data structure manager level. These information is now stored in the manager as opposed to the data structures (qcir, zx, tableau,...) themselves. After this change, if we want to add a new manager, we don't need to modify the data structure's definition. 

All tests pass.

## API Impact

To accommodate for these changes, the signature of the following two template functions are modified:

```
template <typename T>
- std::string dvlab::utils::data_structure_info_string(T const& t);
+ std::string dvlab::utils::data_structure_info_string(dvlab::utils::DataStructureManager<T> const& mgr, size_t id);

template <typename T>
- std::string dvlab::utils::data_structure_name(T const& t) {
+ std::string dvlab::utils::data_structure_name(dvlab::utils::DataStructureManager<T> const& mgr, size_t id);
```

These two functions are used by the manager template to customize display for commands like `xxx list`.

Check the diff for `src/cmd/qcir_mgr.hpp` for an example of how to set up these functions.








