### PR TITLE
Bug/help msgs leads to segfault

### DIFF
--- a/.github/workflows/clang-test-macos.yml
+++ b/.github/workflows/clang-test-macos.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
-      - name: Download llvm-clang, parallel and coreutils
+      - name: Download llvm-clang, parallel, coreutils and OpenBLAS
         run: |
-          brew install llvm@18 parallel coreutils
+          brew install llvm@18 parallel coreutils openblas
           echo 'export PATH="$(brew --prefix)/opt/llvm@18/bin:$PATH"' >> /Users/runner/.bash_profile
           echo 'export LDFLAGS="-L$(brew --prefix)/opt/llvm@18/lib"' >> /Users/runner/.bash_profile
           echo 'export CPPFLAGS="-I$(brew --prefix)/opt/llvm@18/include"' >> /Users/runner/.bash_profile

--- a/.github/workflows/clang-test-macos.yml
+++ b/.github/workflows/clang-test-macos.yml
@@ -17,8 +17,9 @@ jobs:
         run: |
           brew install llvm@18 parallel coreutils openblas
           echo 'export PATH="$(brew --prefix)/opt/llvm@18/bin:$PATH"' >> /Users/runner/.bash_profile
-          echo 'export LDFLAGS="-L$(brew --prefix)/opt/llvm@18/lib"' >> /Users/runner/.bash_profile
-          echo 'export CPPFLAGS="-I$(brew --prefix)/opt/llvm@18/include"' >> /Users/runner/.bash_profile
+          echo 'export LDFLAGS="-L$(brew --prefix)/opt/llvm@18/lib -L$(brew --prefix)/opt/openblas/lib $LDFLAGS"' >> /Users/runner/.bash_profile
+          echo 'export CPPFLAGS="-I$(brew --prefix)/opt/llvm@18/include -I$(brew --prefix)/opt/openblas/include $CPPFLAGS"' >> /Users/runner/.bash_profile
+          echo 'export CMAKE_PREFIX_PATH="$(brew --prefix)/opt/openblas:$CMAKE_PREFIX_PATH"' >> /Users/runner/.bash_profile
 
       - name: Build and test qsyn
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,11 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 # Set BLA_VENDOR before project() so it's available during initialization
 # Use CACHE so it persists across build directories (release vs debug)
 set(BLA_VENDOR OpenBLAS CACHE STRING "BLAS vendor to search for")
-set(BLA_PREFER_PKGCONFIG ON CACHE BOOL "Prefer pkg-config for BLAS")
+# Prefer pkg-config on Linux where it works, but not on macOS where OpenBLAS
+# from Homebrew doesn't provide pkg-config files
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(BLA_PREFER_PKGCONFIG ON CACHE BOOL "Prefer pkg-config for BLAS")
+endif()
 
 include(FetchContent)
 include(CheckCXXCompilerFlag)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ set(CMAKE_CXX_FLAGS "")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 
+# Set BLA_VENDOR before project() so it's available during initialization
+# Use CACHE so it persists across build directories (release vs debug)
+set(BLA_VENDOR OpenBLAS CACHE STRING "BLAS vendor to search for")
+set(BLA_PREFER_PKGCONFIG ON CACHE BOOL "Prefer pkg-config for BLAS")
+
 include(FetchContent)
 include(CheckCXXCompilerFlag)
 set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
@@ -84,7 +89,6 @@ include(scripts/cmake/target_link_libraries_system.cmake)
 
 # find_package(OpenMP REQUIRED)
 
-set(BLA_VENDER OpenBLAS)
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 UNAME_S := $(shell uname -s)
+ARGS := "" # rules can use this variable to pass arguments to other scripts
 
 # On MacOS, the default compiler is clang
 ifeq ($(UNAME_S), Darwin)
@@ -93,7 +94,7 @@ test-update:
 
 # run clang-format and clang-tidy on the source code
 lint:
-	./scripts/LINT
+	./scripts/LINT $(ARGS)
 .PHONY: lint
 
 clean:

--- a/scripts/LINT
+++ b/scripts/LINT
@@ -1,5 +1,62 @@
 #!/usr/bin/env bash
 
+# Default versions (empty means use default command)
+CLANG_FORMAT_CMD="clang-format"
+CLANG_TIDY_CMD="clang-tidy"
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --clang-format-version|-f)
+            if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+                CLANG_FORMAT_CMD="clang-format-$2"
+                shift 2
+            else
+                echo "Error: --clang-format-version requires a version number"
+                exit 1
+            fi
+            ;;
+        --clang-tidy-version|-t)
+            if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+                CLANG_TIDY_CMD="clang-tidy-$2"
+                shift 2
+            else
+                echo "Error: --clang-tidy-version requires a version number"
+                exit 1
+            fi
+            ;;
+        --help|-h)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --clang-format-version, -f VERSION  Specify clang-format version (e.g., 15, 16)"
+            echo "  --clang-tidy-version, -t VERSION    Specify clang-tidy version (e.g., 15, 16)"
+            echo "  --help, -h                          Show this help message"
+            echo ""
+            echo "Examples:"
+            echo "  $0 -f 15 -t 15    # Use clang-format-15 and clang-tidy-15"
+            echo "  $0 -f 16           # Use clang-format-16 and default clang-tidy"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Verify that the specified commands exist
+if [ ! -x "$(command -v "$CLANG_FORMAT_CMD")" ]; then
+    echo "Error: $CLANG_FORMAT_CMD is not installed or not found in PATH"
+    exit 1
+fi
+
+if [ ! -x "$(command -v "$CLANG_TIDY_CMD")" ]; then
+    echo "Error: $CLANG_TIDY_CMD is not installed or not found in PATH"
+    exit 1
+fi
+
 function num_procs() {
     if [ "$(uname)" == "Darwin" ]; then
         sysctl -n hw.logicalcpu
@@ -14,14 +71,16 @@ if [ ! -x "$(command -v parallel)" ]; then
 fi
 
 format_one() {
-    clang-format -i "$1"
+    "$CLANG_FORMAT_CMD" -i "$1"
 }
 export -f format_one
+export CLANG_FORMAT_CMD
 
 lint_one() {
-    clang-tidy -p build "$1" --quiet 2>&1 | grep -v -E "warnings? generated"
+    "$CLANG_TIDY_CMD" -p build "$1" --quiet 2>&1 | grep -v -E "warnings? generated"
 }
 export -f lint_one
+export CLANG_TIDY_CMD
 
 FILES=$(find ./src -regex '.*\.[ch]pp' -type f)
 CPPS=$(find ./src -regex '.*\.cpp' -type f)

--- a/src/util/tabler.cpp
+++ b/src/util/tabler.cpp
@@ -20,7 +20,11 @@ namespace dvlab {
 Tabler::Tabler() = default;
 
 size_t Tabler::_get_string_width(std::string_view str) const {
-    return unicode::display_width(std::string(str));
+    int width = unicode::display_width(std::string(str));
+    // display_width can return -1 on error, which when cast to size_t
+    // becomes SIZE_MAX This would break table formatting,
+    // so we treat errors as 0 width
+    return width < 0 ? 0 : static_cast<size_t>(width);
 }
 
 size_t Tabler::n_columns() const {

--- a/src/util/tabler.cpp
+++ b/src/util/tabler.cpp
@@ -20,7 +20,7 @@ namespace dvlab {
 Tabler::Tabler() = default;
 
 size_t Tabler::_get_string_width(std::string_view str) const {
-    int width = unicode::display_width(std::string(str));
+    int const width = unicode::display_width(std::string(str));
     // display_width can return -1 on error, which when cast to size_t
     // becomes SIZE_MAX This would break table formatting,
     // so we treat errors as 0 width

--- a/tests/cli/dof/qcir-help-msg.dof
+++ b/tests/cli/dof/qcir-help-msg.dof
@@ -1,0 +1,1 @@
+qcir --help

--- a/tests/cli/ref/qcir-help-msg.log
+++ b/tests/cli/ref/qcir-help-msg.log
@@ -1,0 +1,31 @@
+qsyn> qcir --help
+Usage: qcir [-h] [list | checkout | new | delete | copy | compose | tensor-product | read | write | print | draw | adjoint | gate | qubit | optimize | translate | oracle | equiv | to-basic] ...
+
+Description:
+  QCir commands
+
+Options:
+  flag  -h, --help    show this help message 
+
+Subcommands:
+[list | checkout | new | delete | copy | compose | tensor-product | read | write | print | draw | adjoint | gate | qubit | optimize | translate | oracle | equiv | to-basic]  
+    list            List all QCirs                                                                                                                                                                                               
+    checkout        Checkout to QCir with the ID specified                                                                                                                                                                       
+    new             Create a new QCir                                                                                                                                                                                            
+    delete          Delete a QCir from the list                                                                                                                                                                                  
+    copy            Copy a QCir                                                                                                                                                                                                  
+    compose         compose a QCir                                                                                                                                                                                               
+    tensor-product  tensor a QCir                                                                                                                                                                                                
+    read            read a circuit and construct the corresponding netlist                                                                                                                                                       
+    write           write QCir to a QASM file                                                                                                                                                                                    
+    print           print info of QCir                                                                                                                                                                                           
+    draw            draw a QCir. This command relies on qiskit and pdflatex to be present in the system                                                                                                                          
+    adjoint         transform the QCir to its adjoint, i.e., reverse the order of gates and replace each gate with its adjoint version                                                                                           
+    gate            gate commands                                                                                                                                                                                                
+    qubit           qubit commands                                                                                                                                                                                               
+    optimize        optimize QCir                                                                                                                                                                                                
+    translate       translate the circuit into a specific gate set                                                                                                                                                               
+    oracle          synthesize a boolean oracle                                                                                                                                                                                  
+    equiv           check if two circuits are equivalent. A Tableau-based method is used to check the equivalence. If that fails, and the circuits are small enough, also verify the equivalence are through tensor calculation. 
+    to-basic        Convert the QCir to use only basic gates                                                                                                                                                                     
+


### PR DESCRIPTION
## Check List

1. [x] Does your submission pass tests by running `make test`?
2. [x] If you have specified a [no ci] tag, does your submission also pass tests by running `make test-docker`?
3. [x] Have you linted your code locally with `make lint` before submission?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!-- Link to specific issues where it seems fit. -->

### Added

- It is now possible to select formatter and linter versions for the `scripts/LINT` script, used by `make lint`. Usage:
```bash
./scripts/LINT -f <clang-format version> -t <clang-tidy version>
# or
make lint ARGS="-f <clang-format version> -t <clang-tidy version>"
```
This interface is added to make it easier to lint on machines that has other versions as default.

### Fixed
- Using the --help flags in some commands lead to segfault. This bug escaped the regression tests during an earlier refactoring (#154). 

Note that the print format is still off sometimes but I'm filing this PR to hotfix the segfault first.
- CMakeLists.txt does not actually try to find OpenBLAS on Linux (at least for debug build) and MacOS. 