### PR TITLE
chore(ci): update actions and migrate formatting to clang-format 21

### DIFF
--- a/.github/workflows/clang-test-macos.yml
+++ b/.github/workflows/clang-test-macos.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Download llvm-clang, parallel and coreutils
         run: |
           brew install llvm@18 parallel coreutils
+          brew link llvm@18
           echo 'export PATH="$(brew --prefix)/opt/llvm@18/bin:$PATH"' >> /Users/runner/.bash_profile
           echo 'export LDFLAGS="-L$(brew --prefix)/opt/llvm@18/lib"' >> /Users/runner/.bash_profile
           echo 'export CPPFLAGS="-I$(brew --prefix)/opt/llvm@18/include"' >> /Users/runner/.bash_profile

--- a/.github/workflows/clang-test-macos.yml
+++ b/.github/workflows/clang-test-macos.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Download llvm-clang, parallel and coreutils
         run: |
+          brew untap aws/tap || true  # aws/tap is untrusted; untap to suppress Homebrew warning; ignore if not present
           brew install llvm@18 parallel coreutils
           brew link llvm@18
           echo 'export PATH="$(brew --prefix)/opt/llvm@18/bin:$PATH"' >> /Users/runner/.bash_profile

--- a/.github/workflows/clang-test-macos.yml
+++ b/.github/workflows/clang-test-macos.yml
@@ -17,7 +17,6 @@ jobs:
         run: |
           brew untap aws/tap || true  # aws/tap is untrusted; untap to suppress Homebrew warning; ignore if not present
           brew install llvm@18 parallel coreutils
-          brew link llvm@18
           echo 'export PATH="$(brew --prefix)/opt/llvm@18/bin:$PATH"' >> /Users/runner/.bash_profile
           echo 'export LDFLAGS="-L$(brew --prefix)/opt/llvm@18/lib"' >> /Users/runner/.bash_profile
           echo 'export CPPFLAGS="-I$(brew --prefix)/opt/llvm@18/include"' >> /Users/runner/.bash_profile

--- a/.github/workflows/clang-test-macos.yml
+++ b/.github/workflows/clang-test-macos.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Download llvm-clang, parallel and coreutils
         run: |
           brew install llvm@18 parallel coreutils

--- a/.github/workflows/clang-test-ubuntu.yml
+++ b/.github/workflows/clang-test-ubuntu.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Build the test docker image
         run: docker build -t qsyn-test-clang -f docker/clang-test.Dockerfile .
       - name: Run the test docker image

--- a/.github/workflows/gcc-test.yml
+++ b/.github/workflows/gcc-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Build the test docker image
         run: docker build -t qsyn-test-gcc -f docker/gcc-test.Dockerfile .
       - name: Run the test docker image

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: run clang-format
         uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20
         with:
-          sources: "./src"
+          source: "./src"
           exclude: "./vendor ./tests"
           extensions: "h,cpp,hpp,tpp"
           clangFormatVersion: 16

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: run clang-format
-        uses: DoozyX/clang-format-lint-action@v0.16.2
+        uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20
         with:
           sources: "./src"
           exclude: "./vendor ./tests"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,31 +16,5 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v7
 
-      - name: run clang-format
-        uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20
-        with:
-          source: "./src"
-          exclude: "./vendor ./tests"
-          extensions: "h,cpp,hpp,tpp"
-          clangFormatVersion: 16
-
-      # - name: clang-format lint
-      #   run: |
-      #     clang-format-16 --version
-      #     mkdir -p tmp_
-      #     find ./src -type d | xargs -I {} mkdir -p tmp_/{}
-      #     find ./src -regex ".*\.\(h\|cpp\)" -type f | xargs -I {} sh -c 'cp "$1" tmp_/"$1"' -- {}
-      #     cp .clang-format tmp_
-      #     cd tmp_
-      #     find ./src -regex ".*\.\(h\|cpp\)" -type f | xargs -I {} sh -c 'clang-format-16 "$1" > "$1"\ \(Reformatted\)' -- {}
-      #     find ./src -regex ".*\.\(h\|cpp\)" -type f | xargs -I {} sh -c 'cp "$1" "$1"\ \(Original\)' -- {}
-      #     find . -regex ".*\.\(h\|cpp\)" -type f | xargs -I {} sh -c 'colordiff -u "$1"\ \(Original\) "$1"\ \(Reformatted\)' -- {}
-      #     cd ..
-      #     rm -rf tmp_
-      # uses: DoozyX/clang-format-lint-action@v0.15
-      # with:
-      #   source: './src'
-      #   exclude: './vender ./tests'
-      #   extensions: 'h,cpp'
-      #   clangFormatVersion: 15
-      # style: '.clang-format'
+      - name: Check source formatting
+        run: make format-check

--- a/Makefile
+++ b/Makefile
@@ -95,10 +95,15 @@ test-update:
 	./scripts/RUN_TESTS -u
 .PHONY: test-update
 
-# run clang-format and clang-tidy on the source code
+# run clang-tidy on the source code
 lint:
 	./scripts/LINT
 .PHONY: lint
+
+format-check:
+	find ./src -type f \( -name '*.h' -o -name '*.cpp' -o -name '*.hpp' -o -name '*.tpp' \) \
+		-exec pipx run --spec clang-format==21.1.8 clang-format --dry-run --Werror {} +
+.PHONY: format-check
 
 clean:
 	rm -rf build

--- a/README.md
+++ b/README.md
@@ -75,13 +75,20 @@ To build `qsyn`, follow the instructions below:
 
 <details>
 <summary>For Linux Users</summary>
-    
-You'll probably need to install `OpenBLAS` and `LAPACK` libraries. For Ubuntu, you can install them by running
 
-```sh
-sudo apt install libopenblas-dev
-sudo apt install liblapack-dev
-```
+You'll probably need to install `OpenBLAS` and `LAPACK` libraries.
+- For Ubuntu, you can install them by running
+  ```sh
+  sudo apt install libopenblas-dev
+  sudo apt install liblapack-dev
+  ```
+- For Fedora, you can install them by running
+  ```sh
+  sudo dnf install openblas-devel
+  sudo dnf install lapack-devel
+  ```
+- For openSUSE, you can read [this wiki page](https://en.opensuse.org/openSUSE:Science_Linear_algebra_libraries).
+- For other distros, you might be interested in [OpenBLAS install.md](https://github.com/OpenMathLib/OpenBLAS/blob/develop/docs/install.md).
 
 If you are tech-savvy enough to be using a different Linux distribution, we're confident that you can figure out how to install these libraries 😉
 
@@ -97,7 +104,7 @@ This uses the default compiler (gcc/g++) and triggers the CMake build. To overri
 
 <details>
 <summary>For MacOS Users</summary>
-    
+
 Since Qsyn uses C++20 features not fully supported by Apple Clang, install a C++20-capable compiler. Options:
 
 1. **LLVM (clang++)** via Homebrew:
@@ -332,26 +339,26 @@ This architecture is central to qsyn’s flexibility and extensibility. It segre
 ### Data Access and Utilities
 
 `qsyn` provides various data representations for quantum logic. `<dt>` stands for any data representation type, including quantum circuits, ZX diagrams, Tableau, etc.
-| Command | Description |
-| :----- | :---- |
-| `<dt>` list | list all `<dt>`s |
-| `<dt>` checkout | switch focus between `<dt>`s |  
- | `<dt>` print | print `<dt>` information |
-| `<dt>` <new \| delete> | add a new/delete a `<dt>` |
-| `<dt>` <read \| write> | read and write `<dt>` |
-| `<dt>` equiv | verify equivalence of two `<dt>`s |
-| `<dt>` draw | render visualization of `<dt>` |
-| convert `<dt1>` `<dt2>` | convert from `<dt1>` to `<dt2>` |
+| Command                 | Description                       |
+| :---------------------- | :-------------------------------- |
+| `<dt>` list             | list all `<dt>`s                  |
+| `<dt>` checkout         | switch focus between `<dt>`s      |
+| `<dt>` print            | print `<dt>` information          |
+| `<dt>` <new \| delete>  | add a new/delete a `<dt>`         |
+| `<dt>` <read \| write>  | read and write `<dt>`             |
+| `<dt>` equiv            | verify equivalence of two `<dt>`s |
+| `<dt>` draw             | render visualization of `<dt>`    |
+| convert `<dt1>` `<dt2>` | convert from `<dt1>` to `<dt2>`   |
 
 There are also some extra utilities:
-| Command | Description |
-| :----- | :---- |
-| alias | set or unset aliases |
-| help | display helps to commands |
+| Command | Description                    |
+| :------ | :----------------------------- |
+| alias   | set or unset aliases           |
+| help    | display helps to commands      |
 | history | show or export command history |
-| logger | control log levels |
-| set | set or unset variables |
-| usage | show time/memory usage |
+| logger  | control log levels             |
+| set     | set or unset variables         |
+| usage   | show time/memory usage         |
 
 ## License
 
@@ -363,7 +370,7 @@ Certain functions of `qsyn` is enabled by a series of third-party libraries. For
 ## Resources
 
 * Quantum circuit benchmark: [qsyn-benchmark](https://github.com/DVLab-NTU/qsyn-benchmark)
- 
+
 ## Reference
 If you are using Qsyn for your research, it will be greatly appreciated if you cite this publication:
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ Some of the future work for Qsyn includes:
 - **C++**: C++20. We support compilation with (1) **g++-11** or above or (2) **clang++-16** or above. We regularly perform build tests for the two compilers.
 - **BLAS/LAPACK**: OpenBLAS and LAPACK are required (see platform-specific steps below).
 
+### Source formatting
+
+CI and local formatting checks use clang-format **21.1.8** with the repository's
+`.clang-format`. Install [pipx](https://pipx.pypa.io/stable/installation/), then run
+from the repository root:
+
+```sh
+make format-check
+```
+
+This checks `.h`, `.cpp`, `.hpp`, and `.tpp` files under `src` without modifying
+them. pipx downloads the pinned formatter into an isolated environment on first use.
+To format a changed file, run
+`pipx run --spec clang-format==21.1.8 clang-format -i path/to/file.cpp`.
+`make lint` runs clang-tidy separately.
+
 ### Installation
 
 Clone the repository to your local machine by running

--- a/scripts/LINT
+++ b/scripts/LINT
@@ -13,11 +13,6 @@ if [ ! -x "$(command -v parallel)" ]; then
     exit 1
 fi
 
-format_one() {
-    clang-format -i "$1"
-}
-export -f format_one
-
 lint_one() {
     clang-tidy -p build-lint "$1" --quiet 2>&1 \
         | grep -v -E "warnings? generated" \
@@ -28,12 +23,11 @@ lint_one() {
 }
 export -f lint_one
 
-FILES=$(find ./src -regex '.*\.[ch]pp' -type f)
 CPPS=$(find ./src -regex '.*\.cpp' -type f)
 
 # NOTE:
 # We intentionally do NOT auto-run clang-format here.
-# GitHub CI runs clang-format (v16) separately for style checks.
+# GitHub CI runs make format-check separately for style checks.
 # Keeping LINT to clang-tidy only avoids local version drift reformatting code.
 echo "Generating compile commands..."
 # Use Apple clang for the lint build to avoid toolchain/header

--- a/src/argparse/arg_parser.cpp
+++ b/src/argparse/arg_parser.cpp
@@ -488,8 +488,9 @@ bool ArgumentParser::_parse_positional_arguments(TokensSpan tokens, std::vector<
                 fmt::println(stderr, "Error: missing argument \"{}\": expected {}{} arguments!!",
                              arg.get_name(), (lower < upper ? "at least " : ""), lower);
                 return false;
-            } else
+            } else {
                 continue;
+            }
         }
 
         if (!arg.take_action(parse_range)) return false;

--- a/src/argparse/arg_parser.cpp
+++ b/src/argparse/arg_parser.cpp
@@ -52,6 +52,7 @@ bool SubParsers::is_required() const noexcept {
     return _pimpl->required;
 }
 
+SubParsers::MapType& SubParsers::get_subparsers() { return _pimpl->subparsers; }
 SubParsers::MapType const& SubParsers::get_subparsers() const { return _pimpl->subparsers; }
 std::string const& SubParsers::get_help() const { return _pimpl->help; }
 std::string const& SubParsers::get_dest() const { return _pimpl->dest; }

--- a/src/argparse/arg_parser.hpp
+++ b/src/argparse/arg_parser.hpp
@@ -49,6 +49,7 @@ public:
 
     size_t size() const noexcept;
 
+    SubParsers::MapType& get_subparsers();
     SubParsers::MapType const& get_subparsers() const;
     std::string const& get_help() const;
     std::string const& get_dest() const;

--- a/src/cmd/conversion_cmd.cpp
+++ b/src/cmd/conversion_cmd.cpp
@@ -159,8 +159,9 @@ Command convert_from_zx_cmd(zx::ZXGraphMgr& zxgraph_mgr, QCirMgr& qcir_mgr, tens
                         zxgraph_mgr.add(zxgraph_mgr.get_next_id(), std::make_unique<zx::ZXGraph>(std::move(target)));
                         zxgraph_mgr.get()->add_procedure("ZX2QC-Unpermuted");
                         qcir_mgr.get()->add_procedure("ZX2QC-Unpermuted");
-                    } else
+                    } else {
                         qcir_mgr.get()->add_procedure("ZX2QC");
+                    }
 
                     assert(std::ranges::all_of(qcir_mgr.get()->get_gates(), [&](auto* gate) { return gate->get_id() == qcir_mgr.get()->get_gate(gate->get_id())->get_id(); }));
                 }

--- a/src/cmd/qcir_cmd.cpp
+++ b/src/cmd/qcir_cmd.cpp
@@ -322,13 +322,13 @@ dvlab::Command qcir_print_cmd(QCirMgr const& qcir_mgr) {
             if (parser.parsed("--gate")) {
                 auto gate_ids = parser.get<std::vector<size_t>>("--gate");
                 qcir_mgr.get()->print_gates(parser.parsed("--verbose"), gate_ids);
-            } else if (parser.parsed("--diagram"))
+            } else if (parser.parsed("--diagram")) {
                 if (parser.parsed("--verbose")) {
                     qcir_mgr.get()->draw(QCirDrawerType::text);
                 } else {
                     qcir_mgr.get()->print_circuit_diagram();
                 }
-            else if (parser.parsed("--statistics")) {
+            } else if (parser.parsed("--statistics")) {
                 qcir_mgr.get()->print_qcir();
                 qcir_mgr.get()->print_gate_statistics(parser.parsed("--verbose"));
                 fmt::println("Depth      : {}", qcir_mgr.get()->calculate_depth());

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -735,9 +735,9 @@ void Device::print_path(QubitIdType src, QubitIdType dest) const {
         }
     }
     std::vector<PhysicalQubit> const& path = get_path(src, dest);
-    if (path.front().get_id() != src && path.back().get_id() != dest)
+    if (path.front().get_id() != src && path.back().get_id() != dest) {
         fmt::println("No path between {} and {}", src, dest);
-    else {
+    } else {
         fmt::println("Path from {} to {}:", src, dest);
         size_t cnt = 0;
         for (auto& v : path) {

--- a/src/duostra/mapping_eqv_checker.cpp
+++ b/src/duostra/mapping_eqv_checker.cpp
@@ -33,8 +33,9 @@ MappingEquivalenceChecker::MappingEquivalenceChecker(QCir* phy, QCir* log, Devic
     if (init.empty()) {
         auto placer = get_placer(placer_type);
         init        = placer->place_and_assign(_device);
-    } else
+    } else {
         _device.place(init);
+    }
     for (auto const& [i, qubit] : tl::views::enumerate(_logical->get_qubits())) {
         _dependency[i] = _reverse ? qubit.get_last_gate() : qubit.get_first_gate();
     }
@@ -63,8 +64,9 @@ bool MappingEquivalenceChecker::check() {
             }
         } else if (phys_gate->get_num_qubits() > 1) {
             return false;
-        } else if (!execute_single(phys_gate))
+        } else if (!execute_single(phys_gate)) {
             return false;
+        }
     }
     // REVIEW - check remaining gates in logical are swaps
     check_remaining();

--- a/src/duostra/placer.cpp
+++ b/src/duostra/placer.cpp
@@ -59,6 +59,7 @@ std::vector<QubitIdType> BasePlacer::place_and_assign(Device& device) {
  */
 std::vector<QubitIdType> RandomPlacer::_place(Device& device) const {
     std::vector<QubitIdType> assign;
+    assign.reserve(device.get_num_qubits());
     for (size_t i = 0; i < device.get_num_qubits(); ++i)
         assign.emplace_back(i);
 
@@ -76,6 +77,7 @@ std::vector<QubitIdType> RandomPlacer::_place(Device& device) const {
  */
 std::vector<QubitIdType> StaticPlacer::_place(Device& device) const {
     std::vector<QubitIdType> assign;
+    assign.reserve(device.get_num_qubits());
     for (size_t i = 0; i < device.get_num_qubits(); ++i)
         assign.emplace_back(i);
 

--- a/src/qcir/oracle/pebble.cpp
+++ b/src/qcir/oracle/pebble.cpp
@@ -79,7 +79,7 @@ std::optional<DepGraph> from_xag_cuts(XAG const& xag, std::map<XAGNodeID, XAGCut
     };
 
     std::vector<XAGNodeID> optimal_cone_tips = optimal_cut |
-                                               views::filter([&is_input](auto const entry) { return !is_input(entry.first); }) |
+                                               views::filter([&is_input](auto const& entry) { return !is_input(entry.first); }) |
                                                views::keys |
                                                tl::to<std::vector>();
 
@@ -239,7 +239,7 @@ void test_pebble(const size_t num_pebbles, std::istream& input) {
                                                      std::views::values |
                                                      std::views::transform([](const Node& node) {
                                                  return node.dependencies.size();
-                                             }));
+                                                     }));
     const size_t real_num_pebbles = sanitize_num_pebbles(num_pebbles, num_nodes, max_deps);
 
     spdlog::debug("N = {}, P = {}", num_nodes, real_num_pebbles);

--- a/src/qcir/oracle/pebble.cpp
+++ b/src/qcir/oracle/pebble.cpp
@@ -239,7 +239,7 @@ void test_pebble(const size_t num_pebbles, std::istream& input) {
                                                      std::views::values |
                                                      std::views::transform([](const Node& node) {
                                                  return node.dependencies.size();
-                                                     }));
+                                             }));
     const size_t real_num_pebbles = sanitize_num_pebbles(num_pebbles, num_nodes, max_deps);
 
     spdlog::debug("N = {}, P = {}", num_nodes, real_num_pebbles);

--- a/src/qcir/qcir_reader.cpp
+++ b/src/qcir/qcir_reader.cpp
@@ -29,11 +29,11 @@ namespace qsyn::qcir {
 std::optional<QCir> from_file(std::filesystem::path const& filepath) {
     auto const extension = filepath.extension();
 
-    if (extension == ".qasm")
+    if (extension == ".qasm") {
         return qcir::from_qasm(filepath);
-    else if (extension == ".qc")
+    } else if (extension == ".qc") {
         return qcir::from_qc(filepath);
-    else {
+    } else {
         spdlog::error("File format \"{}\" is not supported!!", extension);
         return std::nullopt;
     }
@@ -159,9 +159,9 @@ std::optional<QCir> from_qc(std::filesystem::path const& filepath) {
                     n_qubit++;
                 }
             }
-        } else if (line.find('#') == 0 || line.empty())
+        } else if (line.find('#') == 0 || line.empty()) {
             continue;
-        else if (line.find("BEGIN") == 0 || line.find("begin") == 0) {
+        } else if (line.find("BEGIN") == 0 || line.find("begin") == 0) {
             qcir.add_qubits(n_qubit);
         } else if (line.find("END") == 0 || line.find("end") == 0) {
             return qcir;

--- a/src/qsyn/qsyn_helper.cpp
+++ b/src/qsyn/qsyn_helper.cpp
@@ -43,7 +43,7 @@ void create_default_qsynrc(dvlab::CommandLineInterface& cli, std::filesystem::pa
     namespace fs = std::filesystem;
 
     if (!fs::is_directory(qsynrc_path.parent_path()) && !fs::create_directories(qsynrc_path.parent_path())) {
-        spdlog::critical("Cannot create directory {}", qsynrc_path.parent_path());
+        spdlog::critical("Cannot create directory {}", qsynrc_path.parent_path().string());
         return;
     }
     // clang-format off
@@ -115,7 +115,7 @@ bool read_qsynrc_file(dvlab::CommandLineInterface& cli, std::filesystem::path qs
     cli.clear_history();
 
     if (result == dvlab::CmdExecResult::error) {
-        spdlog::critical("Some errors occurred while reading the qsynrc file from {}", qsynrc_path);
+        spdlog::critical("Some errors occurred while reading the qsynrc file from {}", qsynrc_path.string());
         return false;
     }
 

--- a/src/tableau/pauli_rotation.hpp
+++ b/src/tableau/pauli_rotation.hpp
@@ -360,8 +360,14 @@ struct fmt::formatter<qsyn::experimental::PauliProduct> {
 
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
-        if (it != end && (*it == '+' || *it == '-' || *it == ' ')) signedness = *it++;
-        if (it != end && (*it == 'c' || *it == 'b')) presentation = *it++;
+        if (it != end && (*it == '+' || *it == '-' || *it == ' ')) {
+            signedness = *it;
+            it         = std::next(it);
+        }
+        if (it != end && (*it == 'c' || *it == 'b')) {
+            presentation = *it;
+            it           = std::next(it);
+        }
         if (it != end && *it != '}') detail::throw_format_error("invalid format");
         return it;
     }
@@ -383,8 +389,14 @@ struct fmt::formatter<qsyn::experimental::PauliRotation> {
 
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
-        if (it != end && (*it == '+' || *it == '-' || *it == ' ')) signedness = *it++;
-        if (it != end && (*it == 'c' || *it == 'b')) presentation = *it++;
+        if (it != end && (*it == '+' || *it == '-' || *it == ' ')) {
+            signedness = *it;
+            it         = std::next(it);
+        }
+        if (it != end && (*it == 'c' || *it == 'b')) {
+            presentation = *it;
+            it           = std::next(it);
+        }
         if (it != end && *it != '}') detail::throw_format_error("invalid format");
         return it;
     }

--- a/src/tableau/stabilizer_tableau.hpp
+++ b/src/tableau/stabilizer_tableau.hpp
@@ -148,8 +148,12 @@ struct fmt::formatter<qsyn::experimental::StabilizerTableau> {
     char presentation = 'c';
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
-        if (it != end && (*it == 'c' || *it == 'b')) presentation = *it++;
-        if (it != end && *it != '}') detail::throw_format_error("invalid format");
+        if (it != end && (*it == 'c' || *it == 'b')) {
+            presentation = *it;
+            it           = std::next(it);
+        }
+        if (it != end && *it != '}')
+            detail::throw_format_error("invalid format");
         return it;
     }
 

--- a/src/tableau/tableau.hpp
+++ b/src/tableau/tableau.hpp
@@ -159,7 +159,10 @@ struct fmt::formatter<qsyn::experimental::SubTableau> {
     char presentation = 'c';
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
-        if (it != end && (*it == 'c' || *it == 'b')) presentation = *it++;
+        if (it != end && (*it == 'c' || *it == 'b')) {
+            presentation = *it;
+            it           = std::next(it);
+        }
         if (it != end && *it != '}') detail::throw_format_error("invalid format");
         return it;
     }
@@ -188,7 +191,10 @@ struct fmt::formatter<qsyn::experimental::Tableau> {
     char presentation = 'c';
     constexpr auto parse(format_parse_context& ctx) {
         auto it = ctx.begin(), end = ctx.end();
-        if (it != end && (*it == 'c' || *it == 'b')) presentation = *it++;
+        if (it != end && (*it == 'c' || *it == 'b')) {
+            presentation = *it;
+            it           = std::next(it);
+        }
         if (it != end && *it != '}') detail::throw_format_error("invalid format");
         return it;
     }

--- a/src/tableau/tableau.hpp
+++ b/src/tableau/tableau.hpp
@@ -103,6 +103,10 @@ public:
         // FIXME - check if the subtableau has the same number of qubits
         _subtableaux.push_back(subtableau);
     }
+    auto push_back(SubTableau&& subtableau) {
+        // FIXME - check if the subtableau has the same number of qubits
+        _subtableaux.push_back(std::move(subtableau));
+    }
 
     template <typename... Args>
     auto emplace_back(Args&&... args) {

--- a/src/tensor/tensor.hpp
+++ b/src/tensor/tensor.hpp
@@ -232,6 +232,7 @@ Tensor<U> operator/(Tensor<U> lhs, Tensor<U> const& rhs) {
 template <typename DT>
 std::vector<size_t> Tensor<DT>::shape() const {
     std::vector<size_t> shape;
+    shape.reserve(dimension());
     for (size_t i = 0; i < dimension(); ++i) {
         shape.emplace_back(_tensor.shape(i));
     }

--- a/src/util/boolean_matrix.cpp
+++ b/src/util/boolean_matrix.cpp
@@ -313,8 +313,8 @@ size_t BooleanMatrix::filter_duplicate_row_operations() {
     for (size_t ith_row_op = 0; ith_row_op < _row_operations.size(); ith_row_op++) {
         auto& [row_src, row_dest] = _row_operations[ith_row_op];
         auto const first_match    = last_used.contains(row_src) &&
-                                 last_used[row_src].row_idx == row_dest &&
-                                 _row_operations[last_used[row_src].op_idx].first == row_src;  // make sure the destinations are matched
+                                    last_used[row_src].row_idx == row_dest &&
+                                    _row_operations[last_used[row_src].op_idx].first == row_src;  // make sure the destinations are matched
 
         auto const second_match = last_used.contains(row_dest) &&
                                   last_used[row_dest].row_idx == row_src &&

--- a/src/util/boolean_matrix.cpp
+++ b/src/util/boolean_matrix.cpp
@@ -313,8 +313,8 @@ size_t BooleanMatrix::filter_duplicate_row_operations() {
     for (size_t ith_row_op = 0; ith_row_op < _row_operations.size(); ith_row_op++) {
         auto& [row_src, row_dest] = _row_operations[ith_row_op];
         auto const first_match    = last_used.contains(row_src) &&
-                                    last_used[row_src].row_idx == row_dest &&
-                                    _row_operations[last_used[row_src].op_idx].first == row_src;  // make sure the destinations are matched
+                                 last_used[row_src].row_idx == row_dest &&
+                                 _row_operations[last_used[row_src].op_idx].first == row_src;  // make sure the destinations are matched
 
         auto const second_match = last_used.contains(row_dest) &&
                                   last_used[row_dest].row_idx == row_src &&

--- a/src/util/data_structure_manager_common_cmd.hpp
+++ b/src/util/data_structure_manager_common_cmd.hpp
@@ -142,8 +142,9 @@ Command mgr_delete_cmd(DataStructureManager<T>& mgr) {
                     mgr.clear();
                 } else if (!parser.parsed("id")) {
                     mgr.remove(SIZE_MAX);
-                } else
+                } else {
                     mgr.remove(parser.get<size_t>("id"));
+                }
 
                 return CmdExecResult::done;
             }};

--- a/src/util/dvlab_string.hpp
+++ b/src/util/dvlab_string.hpp
@@ -9,6 +9,7 @@
 
 #include <charconv>
 #include <concepts>
+#include <iterator>
 #include <exception>
 #include <limits>
 #include <optional>
@@ -79,7 +80,7 @@ namespace views {
 template <typename DelimT>
 requires std::convertible_to<DelimT, std::string_view> || std::convertible_to<DelimT, char>
 inline auto split_to_string_views(std::string_view str, DelimT delim) {
-    return std::views::split(str, delim) | std::views::transform([](auto&& rng) { return std::string_view(&*rng.begin(), std::ranges::distance(rng)); });
+    return std::views::split(str, delim) | std::views::transform([](auto&& rng) { return std::string_view(std::ranges::data(rng), std::ranges::distance(rng)); });
 }
 
 /**
@@ -202,7 +203,7 @@ namespace detail {
 template <typename T>
 requires std::integral<T>
 std::from_chars_result from_chars_wrapper(std::string_view str, T& val) {
-    return std::from_chars(str.data(), str.data() + str.size(), val);
+    return std::from_chars(str.data(), std::to_address(str.end()), val);
 }
 
 template <typename T>
@@ -212,13 +213,13 @@ std::from_chars_result from_chars_wrapper(std::string_view str, T& val) {
     try {
         if constexpr (std::is_same_v<T, float>) {
             val = std::stof(std::string{str}, &pos);
-            return {str.data() + pos, std::errc{}};
+            return {std::next(str.data(), pos), std::errc{}};
         } else if constexpr (std::is_same_v<T, double>) {
             val = std::stod(std::string{str}, &pos);
-            return {str.data() + pos, std::errc{}};
+            return {std::next(str.data(), pos), std::errc{}};
         } else if constexpr (std::is_same_v<T, long double>) {
             val = std::stold(std::string{str}, &pos);
-            return {str.data() + pos, std::errc{}};
+            return {std::next(str.data(), pos), std::errc{}};
         }
     } catch (std::invalid_argument const& e) {
         return {str.data(), std::errc::invalid_argument};
@@ -231,7 +232,7 @@ std::from_chars_result from_chars_wrapper(std::string_view str, T& val) {
 #else
 template <typename T>
 std::from_chars_result from_chars_wrapper(std::string_view str, T& val) {
-    return std::from_chars(str.data(), str.data() + str.size(), val);
+    return std::from_chars(str.data(), std::to_address(str.end()), val);
 }
 
 #endif
@@ -243,7 +244,7 @@ inline std::optional<T> from_string(std::string_view str) {
     T result;
 
     auto [ptr, ec] = detail::from_chars_wrapper<T>(str, result);
-    if (ec == std::errc{} && ptr == str.data() + str.size()) {
+    if (ec == std::errc{} && ptr == std::to_address(str.end())) {
         return result;
     } else {
         // perror(std::make_error_code(ec).message().c_str());

--- a/src/util/dvlab_string.hpp
+++ b/src/util/dvlab_string.hpp
@@ -9,8 +9,8 @@
 
 #include <charconv>
 #include <concepts>
-#include <iterator>
 #include <exception>
+#include <iterator>
 #include <limits>
 #include <optional>
 #include <ranges>

--- a/src/util/ordered_hashtable.hpp
+++ b/src/util/ordered_hashtable.hpp
@@ -52,10 +52,13 @@ public:
 
     template <typename VecIterType>
     class OTableIterator {
+        using _itr_val_ref_t = decltype(std::declval<VecIterType>()->value());
     public:
         using value_type        = Value;
         using difference_type   = std::ptrdiff_t;
         using iterator_category = std::bidirectional_iterator_tag;
+        using reference         = std::conditional_t<std::is_const_v<std::remove_reference_t<_itr_val_ref_t>>, value_type const, value_type>&;
+
         OTableIterator() {}
         OTableIterator(VecIterType const& itr, VecIterType const& begin, VecIterType const& end) : _itr(itr), _begin(begin), _end(end) {}
 
@@ -92,11 +95,16 @@ public:
 
         bool is_valid() const noexcept { return *(this->_itr) != std::nullopt; }
 
-        value_type& operator*() noexcept { return (value_type&)this->_itr->value(); }
-        value_type& operator*() const noexcept { return (value_type&)this->_itr->value(); }
+        // reinterpret_cast is intentional: stored_type (e.g. pair<Key, T>) and value_type
+        // (e.g. pair<Key const, T>) are layout-identical but not statically convertible.
+        // This is the same technique used by libstdc++/libc++ for unordered_map iterators.
+        // `reference` already carries the correct const-ness from VecIterType, so no
+        // qualifiers are stripped by either overload.
+        reference operator*() noexcept { return reinterpret_cast<reference>(this->_itr->value()); }        // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
+        reference operator*() const noexcept { return reinterpret_cast<reference>(this->_itr->value()); }  // NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)
 
-        value_type* operator->() noexcept { return (value_type*)&(this->_itr->value()); }
-        value_type* operator->() const noexcept { return (value_type*)&(this->_itr->value()); }
+        auto* operator->() noexcept { return &(**this); }
+        auto* operator->() const noexcept { return &(**this); }
 
     private:
         VecIterType _itr;

--- a/src/util/ordered_hashtable.hpp
+++ b/src/util/ordered_hashtable.hpp
@@ -53,6 +53,7 @@ public:
     template <typename VecIterType>
     class OTableIterator {
         using _itr_val_ref_t = decltype(std::declval<VecIterType>()->value());
+
     public:
         using value_type        = Value;
         using difference_type   = std::ptrdiff_t;

--- a/src/util/phase.hpp
+++ b/src/util/phase.hpp
@@ -250,7 +250,10 @@ struct fmt::formatter<dvlab::Phase> {
 
     constexpr auto parse(format_parse_context& ctx) -> format_parse_context::iterator {
         auto it = ctx.begin(), end = ctx.end();
-        if (it != end && (*it == 'f' || *it == 'e')) presentation = *it++;
+        if (it != end && (*it == 'f' || *it == 'e')) {
+            presentation = *it;
+            it           = std::next(it);
+        }
         if (it != end && *it != '}') detail::throw_format_error("invalid format");
         return it;
     }

--- a/src/util/terminal_attributes.cpp
+++ b/src/util/terminal_attributes.cpp
@@ -62,7 +62,7 @@ TerminalSize get_terminal_size() {
         csbi.srWindow.Right - csbi.srWindow.Left + 1,
         csbi.srWindow.Bottom - csbi.srWindow.Top + 1};
 #else
-    struct winsize w {};
+    struct winsize w{};
     ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);  // NOLINT(cppcoreguidelines-pro-type-vararg) : conform to POSIX
     return {w.ws_col, w.ws_row};
 #endif  // Windows/Linux

--- a/src/util/trie.cpp
+++ b/src/util/trie.cpp
@@ -96,7 +96,7 @@ std::string Trie::shortest_unique_prefix(std::string_view word) const {
         if (itr->frequency == 1) break;
     }
 
-    return std::string{word.begin(), word.begin() + pos};
+    return std::string{word.substr(0, pos)};
 }
 
 size_t Trie::frequency(std::string_view prefix) const {

--- a/src/zx/flow/gflow.cpp
+++ b/src/zx/flow/gflow.cpp
@@ -79,11 +79,12 @@ void GFlow::_initialize() {  // NOLINT(readability-make-member-function-const) m
             if (_zxgraph->is_gadget_leaf(v)) {
                 _measurement_planes[v] = MP::not_a_qubit;
                 _taken.insert(v);
-            } else if (_zxgraph->is_gadget_axel(v))
+            } else if (_zxgraph->is_gadget_axel(v)) {
                 _measurement_planes[v] = v->has_n_pi_phase() ? MP::yz
                                          : v->phase().denominator() == 2
                                              ? MP::xz
                                              : MP::error;
+            }
             assert(_measurement_planes[v] != MP::error);
         }
     }

--- a/src/zx/simplifier/simplify.hpp
+++ b/src/zx/simplifier/simplify.hpp
@@ -87,7 +87,7 @@ size_t simplify(ZXGraph& g, Rule const& rule) {
  */
 template <typename Rule>
 requires std::is_base_of<ZXRuleTemplate<typename Rule::MatchType>, Rule>::value
-size_t hadamard_simplify(ZXGraph& g, Rule rule) {
+size_t hadamard_simplify(ZXGraph& g, Rule const& rule) {
     std::vector<size_t> match_counts;
 
     while (!stop_requested()) {

--- a/tests/src/util/ordered_hashmap.cpp
+++ b/tests/src/util/ordered_hashmap.cpp
@@ -1,0 +1,22 @@
+#include "util/ordered_hashmap.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <type_traits>
+
+TEST_CASE("ordered_hashmap iterator constness", "[ordered_hashmap]") {
+    using Map = dvlab::utils::ordered_hashmap<int, int>;
+    static_assert(std::is_same_v<std::ranges::range_reference_t<Map>, Map::value_type&>);
+    static_assert(std::is_same_v<std::ranges::range_reference_t<Map const>, Map::value_type const&>);
+
+    Map values{{1, 2}, {3, 4}};
+    auto const& read_only = values;
+    static_assert(std::is_same_v<decltype((read_only.begin()->second)), int const&>);
+
+    values.begin()->second = 5;
+    REQUIRE(read_only.begin()->second == 5);
+    REQUIRE(read_only.cbegin()->first == 1);
+
+    values.erase(1);
+    REQUIRE(read_only.begin()->first == 3);
+    REQUIRE(read_only.begin()->second == 4);
+}


### PR DESCRIPTION
CI previously checked formatting with clang-format 16 while developers used newer versions. CI and local development now share `make format-check`, which runs clang-format 21.1.8 through pipx and checks the same `.h`, `.cpp`, `.hpp`, and `.tpp` files under `src`. The existing `.clang-format` is unchanged; the migration requires one whitespace adjustment.

- Update checkout to v7 and remove the obsolete formatting action and commented workflow steps. Retain the macOS Homebrew tap cleanup and LLVM 18 toolchain selection.
- Document the shared formatting command and keep `make lint` dedicated to clang-tidy.
- Include the existing C++ iterator constness, argument passing, path conversion, and allocation improvements, plus Linux installation documentation updates. Add a regression test for mutable and const `ordered_hashmap` iteration and iteration after erasing an entry.

Validation:

- `make format-check`: exit 0; confirmed malformed files fail for all four extensions, including paths with spaces, while files outside `src` are excluded.
- GCC and Clang Docker build/test entrypoints: both exit 0, each with 39 passing unit test cases and 70 passing integration tests. Local runs reused the pinned JSON source checkout as a download cache.
- The iterator constness assertion passes on this branch and fails with the base branch's headers.
- `git diff --check` and `bash -n scripts/LINT`: exit 0.
- GitHub Actions on `a12d0027`: Lint, Ubuntu GCC, Ubuntu Clang, and macOS Clang all passed. Each build job passed 39 unit test cases and 70 integration tests.
